### PR TITLE
feat(eventstore): add Brainplex nervous-system event envelope

### DIFF
--- a/packages/openclaw-nats-eventstore/CHANGELOG.md
+++ b/packages/openclaw-nats-eventstore/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-28
+
+### Added
+- Nervous-system event envelope support
+
+### Fixed
+- Preserved legacy envelope routing
+
+### Changed
+- Refactored hook mappings and addressed PR #17 review feedback
+
 ## [0.2.1] - 2026-02-19
 
 ### Fixed

--- a/packages/openclaw-nats-eventstore/README.md
+++ b/packages/openclaw-nats-eventstore/README.md
@@ -74,34 +74,41 @@ nats sub "openclaw.events.>"
 
 ## Configuration
 
-Add to the `plugins.entries` section of your `openclaw.json`:
+Since v0.2.0, the plugin uses an **External Config Pattern**. Add the plugin to your `openclaw.json` (minimal config):
 
 ```json
 {
   "plugins": {
     "entries": {
       "nats-eventstore": {
-        "enabled": true,
-        "config": {
-          "enabled": true,
-          "natsUrl": "nats://localhost:4222",
-          "streamName": "openclaw-events",
-          "subjectPrefix": "openclaw.events",
-          "retention": {
-            "maxMessages": -1,
-            "maxBytes": -1,
-            "maxAgeHours": 720
-          },
-          "publishTimeoutMs": 5000,
-          "connectTimeoutMs": 5000,
-          "drainTimeoutMs": 5000,
-          "excludeHooks": ["message_sending"]
-        }
+        "enabled": true
       }
     }
   }
 }
 ```
+
+The plugin will automatically create a default configuration file at `~/.openclaw/plugins/nats-eventstore/config.json`. You can edit this file to configure the plugin:
+
+```json
+{
+  "enabled": true,
+  "natsUrl": "nats://localhost:4222",
+  "streamName": "openclaw-events",
+  "subjectPrefix": "openclaw.events",
+  "retention": {
+    "maxMessages": -1,
+    "maxBytes": -1,
+    "maxAgeHours": 720
+  },
+  "publishTimeoutMs": 5000,
+  "connectTimeoutMs": 5000,
+  "drainTimeoutMs": 5000,
+  "excludeHooks": ["message_sending"]
+}
+```
+
+*(Note: Legacy inline config in `openclaw.json` is still supported for backwards compatibility, but the external config file is recommended.)*
 
 ### Config Options
 
@@ -122,7 +129,7 @@ Add to the `plugins.entries` section of your `openclaw.json`:
 
 ### Authentication
 
-Include credentials in the NATS URL:
+Include credentials in the NATS URL within your external `config.json`:
 
 ```json
 {
@@ -272,7 +279,7 @@ A benchmark script is included in the repository — see `scripts/nats-benchmark
 ## Development
 
 ```bash
-# Run tests (66 tests)
+# Run tests (69 tests)
 npm test
 
 # Run with integration tests (requires NATS on localhost:14222)

--- a/packages/openclaw-nats-eventstore/package.json
+++ b/packages/openclaw-nats-eventstore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vainplex/nats-eventstore",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "OpenClaw plugin: publish agent events to NATS JetStream for audit, replay, and multi-agent sharing",
   "type": "module",
   "main": "dist/index.js",
@@ -46,9 +46,9 @@
     "url": "https://github.com/alberthild/vainplex-openclaw.git",
     "directory": "packages/openclaw-nats-eventstore"
   },
-  "homepage": "https://github.com/alberthild/openclaw-nats-eventstore#readme",
+  "homepage": "https://github.com/alberthild/vainplex-openclaw/tree/main/packages/openclaw-nats-eventstore#readme",
   "bugs": {
-    "url": "https://github.com/alberthild/openclaw-nats-eventstore/issues"
+    "url": "https://github.com/alberthild/vainplex-openclaw/issues"
   },
   "author": "Albert Hild <a.hild@vainplex.de>"
 }

--- a/packages/openclaw-nats-eventstore/src/events.ts
+++ b/packages/openclaw-nats-eventstore/src/events.ts
@@ -82,8 +82,10 @@ export type ClawEvent = {
   agent: string;
   /** Session key (e.g., "main", "viola:telegram:12345") */
   session: string;
-  /** Event type identifier */
+  /** Legacy event type identifier used for backward-compatible consumers/routing. */
   type: EventType;
+  /** Canonical nervous-system event type while the taxonomy rolls out. */
+  canonicalType?: EventType;
   /** Previous event type name while the nervous-system taxonomy rolls out. */
   legacyType?: EventType;
   /** Schema version for the canonical envelope. */

--- a/packages/openclaw-nats-eventstore/src/events.ts
+++ b/packages/openclaw-nats-eventstore/src/events.ts
@@ -1,4 +1,23 @@
 export type EventType =
+  // Brainplex nervous-system canonical events (v1)
+  | "message.in.received"
+  | "message.out.sending"
+  | "message.out.sent"
+  | "tool.call.requested"
+  | "tool.call.executed"
+  | "tool.call.failed"
+  | "run.started"
+  | "run.ended"
+  | "run.failed"
+  | "model.input.observed"
+  | "model.output.observed"
+  | "session.started"
+  | "session.ended"
+  | "session.compaction.started"
+  | "session.compaction.ended"
+  | "session.reset"
+  | "gateway.started"
+  | "gateway.stopped"
   // Core (backward-compatible with PR #18171)
   | "msg.in"
   | "msg.out"
@@ -15,9 +34,44 @@ export type EventType =
   | "session.end"
   | "session.compaction_start"
   | "session.compaction_end"
-  | "session.reset"
   | "gateway.start"
   | "gateway.stop";
+
+export type Visibility = "public" | "internal" | "confidential" | "secret";
+
+export type EventSource = {
+  plugin: string;
+  host?: string;
+};
+
+export type EventActor = {
+  agentId?: string;
+  userId?: string;
+  channel?: string;
+};
+
+export type EventScope = {
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolCallId?: string;
+  messageId?: string;
+  jobId?: string;
+};
+
+export type EventTrace = {
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  causationId?: string;
+  correlationId?: string;
+};
+
+export type EventRedaction = {
+  applied: boolean;
+  policy?: string;
+  omittedFields?: string[];
+};
 
 export type ClawEvent = {
   /** Unique event ID (UUIDv4) */
@@ -30,12 +84,46 @@ export type ClawEvent = {
   session: string;
   /** Event type identifier */
   type: EventType;
+  /** Previous event type name while the nervous-system taxonomy rolls out. */
+  legacyType?: EventType;
+  /** Schema version for the canonical envelope. */
+  schemaVersion: 1;
+  /** Component that emitted the event. */
+  source: EventSource;
+  /** Actor metadata (agent/user/channel). */
+  actor: EventActor;
+  /** Run/session/tool/message scope metadata. */
+  scope: EventScope;
+  /** Trace and causality metadata. */
+  trace: EventTrace;
+  /** Visibility tier for consumers and projections. */
+  visibility: Visibility;
+  /** Redaction metadata for omitted or transformed payload fields. */
+  redaction?: EventRedaction;
   /** Event-specific payload */
   payload: Record<string, unknown>;
 };
 
 /** All known event types as an array (useful for validation/testing) */
 export const ALL_EVENT_TYPES: EventType[] = [
+  "message.in.received",
+  "message.out.sending",
+  "message.out.sent",
+  "tool.call.requested",
+  "tool.call.executed",
+  "tool.call.failed",
+  "run.started",
+  "run.ended",
+  "run.failed",
+  "model.input.observed",
+  "model.output.observed",
+  "session.started",
+  "session.ended",
+  "session.compaction.started",
+  "session.compaction.ended",
+  "session.reset",
+  "gateway.started",
+  "gateway.stopped",
   "msg.in",
   "msg.out",
   "msg.sending",
@@ -50,7 +138,6 @@ export const ALL_EVENT_TYPES: EventType[] = [
   "session.end",
   "session.compaction_start",
   "session.compaction_end",
-  "session.reset",
   "gateway.start",
   "gateway.stop",
 ];

--- a/packages/openclaw-nats-eventstore/src/events.ts
+++ b/packages/openclaw-nats-eventstore/src/events.ts
@@ -1,4 +1,4 @@
-export type EventType =
+export type CanonicalEventType =
   // Brainplex nervous-system canonical events (v1)
   | "message.in.received"
   | "message.out.sending"
@@ -17,7 +17,9 @@ export type EventType =
   | "session.compaction.ended"
   | "session.reset"
   | "gateway.started"
-  | "gateway.stopped"
+  | "gateway.stopped";
+
+export type LegacyEventType =
   // Core (backward-compatible with PR #18171)
   | "msg.in"
   | "msg.out"
@@ -36,6 +38,8 @@ export type EventType =
   | "session.compaction_end"
   | "gateway.start"
   | "gateway.stop";
+
+export type EventType = CanonicalEventType | LegacyEventType;
 
 export type Visibility = "public" | "internal" | "confidential" | "secret";
 
@@ -85,9 +89,9 @@ export type ClawEvent = {
   /** Legacy event type identifier used for backward-compatible consumers/routing. */
   type: EventType;
   /** Canonical nervous-system event type while the taxonomy rolls out. */
-  canonicalType?: EventType;
+  canonicalType?: CanonicalEventType;
   /** Previous event type name while the nervous-system taxonomy rolls out. */
-  legacyType?: EventType;
+  legacyType?: LegacyEventType;
   /** Schema version for the canonical envelope. */
   schemaVersion: 1;
   /** Component that emitted the event. */
@@ -106,8 +110,7 @@ export type ClawEvent = {
   payload: Record<string, unknown>;
 };
 
-/** All known event types as an array (useful for validation/testing) */
-export const ALL_EVENT_TYPES: EventType[] = [
+export const CANONICAL_EVENT_TYPES: CanonicalEventType[] = [
   "message.in.received",
   "message.out.sending",
   "message.out.sent",
@@ -126,6 +129,9 @@ export const ALL_EVENT_TYPES: EventType[] = [
   "session.reset",
   "gateway.started",
   "gateway.stopped",
+];
+
+export const LEGACY_EVENT_TYPES: LegacyEventType[] = [
   "msg.in",
   "msg.out",
   "msg.sending",
@@ -142,4 +148,10 @@ export const ALL_EVENT_TYPES: EventType[] = [
   "session.compaction_end",
   "gateway.start",
   "gateway.stop",
+];
+
+/** All known event types as an array (useful for validation/testing) */
+export const ALL_EVENT_TYPES: EventType[] = [
+  ...CANONICAL_EVENT_TYPES,
+  ...LEGACY_EVENT_TYPES,
 ];

--- a/packages/openclaw-nats-eventstore/src/hook-mappings.ts
+++ b/packages/openclaw-nats-eventstore/src/hook-mappings.ts
@@ -1,0 +1,216 @@
+import type { ClawEvent, EventType, Visibility } from "./events.js";
+
+export type PayloadMapper = (event: any, ctx: any) => Record<string, unknown>;
+export type EventTypeMapper = EventType | ((event: any, ctx: any) => EventType);
+
+export type HookMapping = {
+  hookName: string;
+  eventType: EventTypeMapper;
+  legacyType?: EventType;
+  visibility?: Visibility;
+  redaction?: ClawEvent["redaction"];
+  mapper: PayloadMapper;
+  /** If true, uses "system" as agent/session (gateway hooks). */
+  systemEvent?: boolean;
+};
+
+/** Additional events to emit from the same hook (e.g. run.error from agent_end). */
+export type ExtraEmitter = {
+  hookName: string;
+  eventType: EventTypeMapper;
+  legacyType?: EventType;
+  visibility?: Visibility;
+  redaction?: ClawEvent["redaction"];
+  condition: (event: any) => boolean;
+  mapper: PayloadMapper;
+};
+
+export const HOOK_MAPPINGS: HookMapping[] = [
+  {
+    hookName: "message_received",
+    eventType: "message.in.received",
+    legacyType: "msg.in",
+    visibility: "confidential",
+    mapper: (event, ctx) => ({
+      from: event.from,
+      content: event.content,
+      timestamp: event.timestamp,
+      channel: ctx?.channelId,
+      metadata: event.metadata,
+    }),
+  },
+  {
+    hookName: "message_sending",
+    eventType: "message.out.sending",
+    legacyType: "msg.sending",
+    visibility: "confidential",
+    mapper: (event, ctx) => ({
+      to: event.to,
+      content: event.content,
+      channel: ctx?.channelId,
+    }),
+  },
+  {
+    hookName: "message_sent",
+    eventType: "message.out.sent",
+    legacyType: "msg.out",
+    visibility: "confidential",
+    mapper: (event, ctx) => ({
+      to: event.to,
+      content: event.content,
+      success: event.success,
+      error: event.error,
+      channel: ctx?.channelId,
+    }),
+  },
+  {
+    hookName: "before_tool_call",
+    eventType: "tool.call.requested",
+    legacyType: "tool.call",
+    visibility: "confidential",
+    mapper: (event) => ({
+      toolName: event.toolName,
+      params: event.params,
+    }),
+  },
+  {
+    hookName: "after_tool_call",
+    eventType: (event) => event.error ? "tool.call.failed" : "tool.call.executed",
+    legacyType: "tool.result",
+    visibility: "confidential",
+    mapper: (event) => ({
+      toolName: event.toolName,
+      params: event.params,
+      result: event.result,
+      error: event.error,
+      durationMs: event.durationMs,
+    }),
+  },
+  {
+    hookName: "before_agent_start",
+    eventType: "run.started",
+    legacyType: "run.start",
+    visibility: "confidential",
+    mapper: (event) => ({ prompt: event.prompt }),
+  },
+  {
+    hookName: "agent_end",
+    eventType: "run.ended",
+    legacyType: "run.end",
+    mapper: (event) => ({
+      success: event.success,
+      error: event.error,
+      durationMs: event.durationMs,
+      messageCount: event.messages?.length ?? 0,
+    }),
+  },
+  {
+    hookName: "llm_input",
+    eventType: "model.input.observed",
+    legacyType: "llm.input",
+    redaction: { applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] },
+    mapper: (event) => ({
+      runId: event.runId,
+      sessionId: event.sessionId,
+      provider: event.provider,
+      model: event.model,
+      systemPromptLength: event.systemPrompt?.length ?? 0,
+      promptLength: event.prompt?.length ?? 0,
+      historyMessageCount: event.historyMessages?.length ?? 0,
+      imagesCount: event.imagesCount ?? 0,
+    }),
+  },
+  {
+    hookName: "llm_output",
+    eventType: "model.output.observed",
+    legacyType: "llm.output",
+    redaction: { applied: true, omittedFields: ["assistantTexts"] },
+    mapper: (event) => {
+      const texts = event.assistantTexts ?? [];
+      return {
+        runId: event.runId,
+        sessionId: event.sessionId,
+        provider: event.provider,
+        model: event.model,
+        assistantTextCount: texts.length,
+        assistantTextTotalLength: texts.reduce(
+          (s: number, t: string) => s + (t?.length ?? 0),
+          0,
+        ),
+        usage: event.usage,
+      };
+    },
+  },
+  {
+    hookName: "before_compaction",
+    eventType: "session.compaction.started",
+    legacyType: "session.compaction_start",
+    mapper: (event) => ({
+      messageCount: event.messageCount,
+      compactingCount: event.compactingCount,
+      tokenCount: event.tokenCount,
+    }),
+  },
+  {
+    hookName: "after_compaction",
+    eventType: "session.compaction.ended",
+    legacyType: "session.compaction_end",
+    mapper: (event) => ({
+      messageCount: event.messageCount,
+      compactedCount: event.compactedCount,
+      tokenCount: event.tokenCount,
+    }),
+  },
+  {
+    hookName: "before_reset",
+    eventType: "session.reset",
+    mapper: (event) => ({ reason: event.reason }),
+  },
+  {
+    hookName: "session_start",
+    eventType: "session.started",
+    legacyType: "session.start",
+    mapper: (event) => ({
+      sessionId: event.sessionId,
+      resumedFrom: event.resumedFrom,
+    }),
+  },
+  {
+    hookName: "session_end",
+    eventType: "session.ended",
+    legacyType: "session.end",
+    mapper: (event) => ({
+      sessionId: event.sessionId,
+      messageCount: event.messageCount,
+      durationMs: event.durationMs,
+    }),
+  },
+  {
+    hookName: "gateway_start",
+    eventType: "gateway.started",
+    legacyType: "gateway.start",
+    mapper: (event) => ({ port: event.port }),
+    systemEvent: true,
+  },
+  {
+    hookName: "gateway_stop",
+    eventType: "gateway.stopped",
+    legacyType: "gateway.stop",
+    mapper: (event) => ({ reason: event.reason }),
+    systemEvent: true,
+  },
+];
+
+export const EXTRA_EMITTERS: ExtraEmitter[] = [
+  {
+    hookName: "agent_end",
+    eventType: "run.failed",
+    legacyType: "run.error",
+    condition: (event) => !event.success,
+    mapper: (event) => ({
+      success: false,
+      error: event.error,
+      durationMs: event.durationMs,
+    }),
+  },
+];

--- a/packages/openclaw-nats-eventstore/src/hook-mappings.ts
+++ b/packages/openclaw-nats-eventstore/src/hook-mappings.ts
@@ -1,12 +1,15 @@
-import type { ClawEvent, EventType, Visibility } from "./events.js";
+import type { ClawEvent, EventType, CanonicalEventType, LegacyEventType, Visibility } from "./events.js";
 
-export type PayloadMapper = (event: any, ctx: any) => Record<string, unknown>;
-export type EventTypeMapper = EventType | ((event: any, ctx: any) => EventType);
+export type HookEventPayload = Record<string, unknown>;
+export type HookContext = Record<string, unknown>;
+
+export type PayloadMapper = (event: HookEventPayload, ctx?: HookContext) => Record<string, unknown>;
+export type EventTypeMapper = CanonicalEventType | ((event: HookEventPayload, ctx?: HookContext) => CanonicalEventType);
 
 export type HookMapping = {
   hookName: string;
   eventType: EventTypeMapper;
-  legacyType?: EventType;
+  legacyType?: LegacyEventType;
   visibility?: Visibility;
   redaction?: ClawEvent["redaction"];
   mapper: PayloadMapper;
@@ -18,10 +21,10 @@ export type HookMapping = {
 export type ExtraEmitter = {
   hookName: string;
   eventType: EventTypeMapper;
-  legacyType?: EventType;
+  legacyType?: LegacyEventType;
   visibility?: Visibility;
   redaction?: ClawEvent["redaction"];
-  condition: (event: any) => boolean;
+  condition: (event: HookEventPayload) => boolean;
   mapper: PayloadMapper;
 };
 
@@ -101,7 +104,7 @@ export const HOOK_MAPPINGS: HookMapping[] = [
       success: event.success,
       error: event.error,
       durationMs: event.durationMs,
-      messageCount: event.messages?.length ?? 0,
+      messageCount: Array.isArray(event.messages) ? event.messages.length : 0,
     }),
   },
   {
@@ -114,9 +117,9 @@ export const HOOK_MAPPINGS: HookMapping[] = [
       sessionId: event.sessionId,
       provider: event.provider,
       model: event.model,
-      systemPromptLength: event.systemPrompt?.length ?? 0,
-      promptLength: event.prompt?.length ?? 0,
-      historyMessageCount: event.historyMessages?.length ?? 0,
+      systemPromptLength: typeof event.systemPrompt === "string" ? event.systemPrompt.length : 0,
+      promptLength: typeof event.prompt === "string" ? event.prompt.length : 0,
+      historyMessageCount: Array.isArray(event.historyMessages) ? event.historyMessages.length : 0,
       imagesCount: event.imagesCount ?? 0,
     }),
   },
@@ -126,7 +129,7 @@ export const HOOK_MAPPINGS: HookMapping[] = [
     legacyType: "llm.output",
     redaction: { applied: true, omittedFields: ["assistantTexts"] },
     mapper: (event) => {
-      const texts = event.assistantTexts ?? [];
+      const texts = Array.isArray(event.assistantTexts) ? event.assistantTexts : [];
       return {
         runId: event.runId,
         sessionId: event.sessionId,
@@ -134,7 +137,7 @@ export const HOOK_MAPPINGS: HookMapping[] = [
         model: event.model,
         assistantTextCount: texts.length,
         assistantTextTotalLength: texts.reduce(
-          (s: number, t: string) => s + (t?.length ?? 0),
+          (s: number, t: unknown) => s + (typeof t === "string" ? t.length : 0),
           0,
         ),
         usage: event.usage,

--- a/packages/openclaw-nats-eventstore/src/hooks.ts
+++ b/packages/openclaw-nats-eventstore/src/hooks.ts
@@ -4,6 +4,13 @@ import type { PluginLogger } from "./nats-client.js";
 import type { NatsEventStoreConfig } from "./config.js";
 import type { ClawEvent, EventType, Visibility } from "./events.js";
 import { extractAgentId, buildSubject } from "./util.js";
+import {
+  HOOK_MAPPINGS,
+  EXTRA_EMITTERS,
+  type HookMapping,
+  type ExtraEmitter,
+  type EventTypeMapper,
+} from "./hook-mappings.js";
 
 type HookCtx = {
   agentId?: string;
@@ -89,6 +96,35 @@ function deriveEventId(
   return randomUUID();
 }
 
+function buildActor(agent: string, ctx: HookCtx): ClawEvent["actor"] {
+  return {
+    agentId: agent === "system" ? undefined : agent,
+    userId: firstString(ctx.senderId),
+    channel: firstString(ctx.channelId),
+  };
+}
+
+function buildScope(payload: Record<string, unknown>, ctx: HookCtx): ClawEvent["scope"] {
+  return {
+    sessionKey: firstString(ctx.sessionKey),
+    sessionId: firstString(ctx.sessionId),
+    runId: firstString(ctx.runId, payload.runId),
+    toolCallId: firstString(payload.toolCallId),
+    messageId: firstString(ctx.messageId, payload.messageId),
+    jobId: firstString(ctx.jobId),
+  };
+}
+
+function buildTrace(payload: Record<string, unknown>, ctx: HookCtx, trace: any): ClawEvent["trace"] {
+  return {
+    traceId: firstString(ctx.traceId, trace.traceId),
+    spanId: firstString(ctx.spanId, trace.spanId),
+    parentSpanId: firstString(ctx.parentSpanId, trace.parentSpanId),
+    causationId: firstString(payload.causationId),
+    correlationId: firstString(ctx.runId, ctx.sessionId, ctx.sessionKey),
+  };
+}
+
 function buildEnvelope(
   canonicalType: EventType,
   agent: string,
@@ -110,26 +146,9 @@ function buildEnvelope(
     legacyType: options.legacyType,
     schemaVersion: 1,
     source: { plugin: "nats-eventstore" },
-    actor: {
-      agentId: agent === "system" ? undefined : agent,
-      userId: firstString(ctx.senderId),
-      channel: firstString(ctx.channelId),
-    },
-    scope: {
-      sessionKey: firstString(ctx.sessionKey),
-      sessionId: firstString(ctx.sessionId),
-      runId: firstString(ctx.runId, payload.runId),
-      toolCallId: firstString(payload.toolCallId),
-      messageId: firstString(ctx.messageId, payload.messageId),
-      jobId: firstString(ctx.jobId),
-    },
-    trace: {
-      traceId: firstString(ctx.traceId, trace.traceId),
-      spanId: firstString(ctx.spanId, trace.spanId),
-      parentSpanId: firstString(ctx.parentSpanId, trace.parentSpanId),
-      causationId: firstString(payload.causationId),
-      correlationId: firstString(ctx.runId, ctx.sessionId, ctx.sessionKey),
-    },
+    actor: buildActor(agent, ctx),
+    scope: buildScope(payload, ctx),
+    trace: buildTrace(payload, ctx, trace),
     visibility: options.visibility ?? "internal",
     redaction: options.redaction,
     payload,
@@ -158,223 +177,78 @@ function publish(
   });
 }
 
-// ── Hook-to-event mapping table ──
+function resolveEventType(mapper: EventTypeMapper, event: any, ctx: any): EventType {
+  return typeof mapper === "function" ? mapper(event, ctx) : mapper;
+}
 
-type PayloadMapper = (event: any, ctx: any) => Record<string, unknown>;
-type EventTypeMapper = EventType | ((event: any, ctx: any) => EventType);
+function emitExtras(
+  extras: ExtraEmitter[],
+  event: any,
+  ctx: any,
+  pub: (type: EventType, ctxPayload: HookCtx, payload: Record<string, unknown>, options?: PublishOptions) => void
+): void {
+  for (const extra of extras) {
+    if (extra.condition(event)) {
+      const extraType = resolveEventType(extra.eventType, event, ctx);
+      pub(extraType, ctx, extra.mapper(event, ctx), {
+        legacyType: extra.legacyType,
+        visibility: extra.visibility,
+        redaction: extra.redaction,
+        originalEvent: event,
+      });
+    }
+  }
+}
 
-type HookMapping = {
-  hookName: string;
-  eventType: EventTypeMapper;
-  legacyType?: EventType;
-  visibility?: Visibility;
-  redaction?: ClawEvent["redaction"];
-  mapper: PayloadMapper;
-  /** If true, uses "system" as agent/session (gateway hooks). */
-  systemEvent?: boolean;
-};
+function publishHookResult(
+  getClient: () => NatsClient | null,
+  config: NatsEventStoreConfig,
+  logger: PluginLogger
+) {
+  return (
+    type: EventType,
+    ctxPayload: HookCtx,
+    payload: Record<string, unknown>,
+    options: PublishOptions = {},
+  ): void => {
+    const agent = extractAgentId(ctxPayload);
+    const session = ctxPayload.sessionKey ?? ctxPayload.sessionId ?? "unknown";
+    publish(getClient, config, type, agent, session, payload, logger, { ...options, ctx: ctxPayload });
+  };
+}
 
-/** Additional events to emit from the same hook (e.g. run.error from agent_end). */
-type ExtraEmitter = {
-  hookName: string;
-  eventType: EventTypeMapper;
-  legacyType?: EventType;
-  visibility?: Visibility;
-  redaction?: ClawEvent["redaction"];
-  condition: (event: any) => boolean;
-  mapper: PayloadMapper;
-};
+function handleHookEvent(
+  mapping: HookMapping,
+  extras: ExtraEmitter[],
+  event: any,
+  ctx: any,
+  config: NatsEventStoreConfig,
+  getClient: () => NatsClient | null,
+  logger: PluginLogger,
+): void {
+  try {
+    const pub = publishHookResult(getClient, config, logger);
+    const payload = mapping.mapper(event, ctx);
+    const eventType = resolveEventType(mapping.eventType, event, ctx);
+    const options: PublishOptions = {
+      legacyType: mapping.legacyType,
+      visibility: mapping.visibility,
+      redaction: mapping.redaction,
+      ctx,
+      originalEvent: event,
+    };
 
-const HOOK_MAPPINGS: HookMapping[] = [
-  {
-    hookName: "message_received",
-    eventType: "message.in.received",
-    legacyType: "msg.in",
-    visibility: "confidential",
-    mapper: (event, ctx) => ({
-      from: event.from,
-      content: event.content,
-      timestamp: event.timestamp,
-      channel: ctx?.channelId,
-      metadata: event.metadata,
-    }),
-  },
-  {
-    hookName: "message_sending",
-    eventType: "message.out.sending",
-    legacyType: "msg.sending",
-    visibility: "confidential",
-    mapper: (event, ctx) => ({
-      to: event.to,
-      content: event.content,
-      channel: ctx?.channelId,
-    }),
-  },
-  {
-    hookName: "message_sent",
-    eventType: "message.out.sent",
-    legacyType: "msg.out",
-    visibility: "confidential",
-    mapper: (event, ctx) => ({
-      to: event.to,
-      content: event.content,
-      success: event.success,
-      error: event.error,
-      channel: ctx?.channelId,
-    }),
-  },
-  {
-    hookName: "before_tool_call",
-    eventType: "tool.call.requested",
-    legacyType: "tool.call",
-    visibility: "confidential",
-    mapper: (event) => ({
-      toolName: event.toolName,
-      params: event.params,
-    }),
-  },
-  {
-    hookName: "after_tool_call",
-    eventType: (event) => event.error ? "tool.call.failed" : "tool.call.executed",
-    legacyType: "tool.result",
-    visibility: "confidential",
-    mapper: (event) => ({
-      toolName: event.toolName,
-      params: event.params,
-      result: event.result,
-      error: event.error,
-      durationMs: event.durationMs,
-    }),
-  },
-  {
-    hookName: "before_agent_start",
-    eventType: "run.started",
-    legacyType: "run.start",
-    visibility: "confidential",
-    mapper: (event) => ({ prompt: event.prompt }),
-  },
-  {
-    hookName: "agent_end",
-    eventType: "run.ended",
-    legacyType: "run.end",
-    mapper: (event) => ({
-      success: event.success,
-      error: event.error,
-      durationMs: event.durationMs,
-      messageCount: event.messages?.length ?? 0,
-    }),
-  },
-  {
-    hookName: "llm_input",
-    eventType: "model.input.observed",
-    legacyType: "llm.input",
-    redaction: { applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] },
-    mapper: (event) => ({
-      runId: event.runId,
-      sessionId: event.sessionId,
-      provider: event.provider,
-      model: event.model,
-      systemPromptLength: event.systemPrompt?.length ?? 0,
-      promptLength: event.prompt?.length ?? 0,
-      historyMessageCount: event.historyMessages?.length ?? 0,
-      imagesCount: event.imagesCount ?? 0,
-    }),
-  },
-  {
-    hookName: "llm_output",
-    eventType: "model.output.observed",
-    legacyType: "llm.output",
-    redaction: { applied: true, omittedFields: ["assistantTexts"] },
-    mapper: (event) => {
-      const texts = event.assistantTexts ?? [];
-      return {
-        runId: event.runId,
-        sessionId: event.sessionId,
-        provider: event.provider,
-        model: event.model,
-        assistantTextCount: texts.length,
-        assistantTextTotalLength: texts.reduce(
-          (s: number, t: string) => s + (t?.length ?? 0),
-          0,
-        ),
-        usage: event.usage,
-      };
-    },
-  },
-  {
-    hookName: "before_compaction",
-    eventType: "session.compaction.started",
-    legacyType: "session.compaction_start",
-    mapper: (event) => ({
-      messageCount: event.messageCount,
-      compactingCount: event.compactingCount,
-      tokenCount: event.tokenCount,
-    }),
-  },
-  {
-    hookName: "after_compaction",
-    eventType: "session.compaction.ended",
-    legacyType: "session.compaction_end",
-    mapper: (event) => ({
-      messageCount: event.messageCount,
-      compactedCount: event.compactedCount,
-      tokenCount: event.tokenCount,
-    }),
-  },
-  {
-    hookName: "before_reset",
-    eventType: "session.reset",
-    mapper: (event) => ({ reason: event.reason }),
-  },
-  {
-    hookName: "session_start",
-    eventType: "session.started",
-    legacyType: "session.start",
-    mapper: (event) => ({
-      sessionId: event.sessionId,
-      resumedFrom: event.resumedFrom,
-    }),
-  },
-  {
-    hookName: "session_end",
-    eventType: "session.ended",
-    legacyType: "session.end",
-    mapper: (event) => ({
-      sessionId: event.sessionId,
-      messageCount: event.messageCount,
-      durationMs: event.durationMs,
-    }),
-  },
-  {
-    hookName: "gateway_start",
-    eventType: "gateway.started",
-    legacyType: "gateway.start",
-    mapper: (event) => ({ port: event.port }),
-    systemEvent: true,
-  },
-  {
-    hookName: "gateway_stop",
-    eventType: "gateway.stopped",
-    legacyType: "gateway.stop",
-    mapper: (event) => ({ reason: event.reason }),
-    systemEvent: true,
-  },
-];
+    if (mapping.systemEvent) {
+      publish(getClient, config, eventType, "system", "system", payload, logger, options);
+    } else {
+      pub(eventType, ctx, payload, options);
+    }
 
-/** Extra events emitted from existing hooks (backward compatibility). */
-const EXTRA_EMITTERS: ExtraEmitter[] = [
-  {
-    hookName: "agent_end",
-    eventType: "run.failed",
-    legacyType: "run.error",
-    condition: (event) => !event.success,
-    mapper: (event) => ({
-      success: false,
-      error: event.error,
-      durationMs: event.durationMs,
-    }),
-  },
-];
+    emitExtras(extras, event, ctx, pub);
+  } catch (err) {
+    logger.warn(`[nats-eventstore] Hook ${mapping.hookName} error: ${err}`);
+  }
+}
 
 /**
  * Register all event hook handlers on the plugin API.
@@ -385,24 +259,6 @@ export function registerEventHooks(
   config: NatsEventStoreConfig,
   getClient: () => NatsClient | null,
 ): void {
-  const logger = api.logger;
-
-  // Helper: publish with agent context extraction
-  const pub = (
-    type: EventType,
-    ctx: HookCtx,
-    payload: Record<string, unknown>,
-    options: PublishOptions = {},
-  ) => {
-    const agent = extractAgentId(ctx);
-    const session = ctx.sessionKey ?? ctx.sessionId ?? "unknown";
-    publish(getClient, config, type, agent, session, payload, logger, { ...options, ctx });
-  };
-
-  const resolveEventType = (mapper: EventTypeMapper, event: any, ctx: any): EventType =>
-    typeof mapper === "function" ? mapper(event, ctx) : mapper;
-
-  // Build lookup for extra emitters per hook
   const extrasByHook = new Map<string, ExtraEmitter[]>();
   for (const extra of EXTRA_EMITTERS) {
     const list = extrasByHook.get(extra.hookName) ?? [];
@@ -410,46 +266,11 @@ export function registerEventHooks(
     extrasByHook.set(extra.hookName, list);
   }
 
-  // Register each hook from the mapping table
   for (const mapping of HOOK_MAPPINGS) {
     if (!shouldPublish(mapping.hookName, config)) continue;
-
     const extras = extrasByHook.get(mapping.hookName) ?? [];
-
     api.on(mapping.hookName, (event: any, ctx: any) => {
-      try {
-        const payload = mapping.mapper(event, ctx);
-
-        const eventType = resolveEventType(mapping.eventType, event, ctx);
-        const options: PublishOptions = {
-          legacyType: mapping.legacyType,
-          visibility: mapping.visibility,
-          redaction: mapping.redaction,
-          ctx,
-          originalEvent: event,
-        };
-
-        if (mapping.systemEvent) {
-          publish(getClient, config, eventType, "system", "system", payload, logger, options);
-        } else {
-          pub(eventType, ctx, payload, options);
-        }
-
-        // Emit any extra events for this hook
-        for (const extra of extras) {
-          if (extra.condition(event)) {
-            const extraType = resolveEventType(extra.eventType, event, ctx);
-            pub(extraType, ctx, extra.mapper(event, ctx), {
-              legacyType: extra.legacyType,
-              visibility: extra.visibility,
-              redaction: extra.redaction,
-              originalEvent: event,
-            });
-          }
-        }
-      } catch (err) {
-        logger.warn(`[nats-eventstore] Hook ${mapping.hookName} error: ${err}`);
-      }
+      handleHookEvent(mapping, extras, event, ctx, config, getClient, api.logger);
     });
   }
 }

--- a/packages/openclaw-nats-eventstore/src/hooks.ts
+++ b/packages/openclaw-nats-eventstore/src/hooks.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { NatsClient } from "./nats-client.js";
 import type { PluginLogger } from "./nats-client.js";
 import type { NatsEventStoreConfig } from "./config.js";
-import type { ClawEvent, EventType } from "./events.js";
+import type { ClawEvent, EventType, Visibility } from "./events.js";
 import { extractAgentId, buildSubject } from "./util.js";
 
 type HookCtx = {
@@ -10,6 +10,18 @@ type HookCtx = {
   sessionKey?: string;
   sessionId?: string;
   channelId?: string;
+  runId?: string;
+  jobId?: string;
+  messageId?: string;
+  senderId?: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  trace?: {
+    traceId?: string;
+    spanId?: string;
+    parentSpanId?: string;
+  };
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,6 +41,65 @@ function shouldPublish(hookName: string, config: NatsEventStoreConfig): boolean 
   return true;
 }
 
+type PublishOptions = {
+  legacyType?: EventType;
+  visibility?: Visibility;
+  redaction?: ClawEvent["redaction"];
+  ctx?: HookCtx;
+};
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function buildEnvelope(
+  type: EventType,
+  agent: string,
+  session: string,
+  payload: Record<string, unknown>,
+  options: PublishOptions = {},
+): ClawEvent {
+  const ctx = options.ctx ?? {};
+  const trace = ctx.trace ?? {};
+
+  return {
+    id: randomUUID(),
+    ts: Date.now(),
+    agent,
+    session,
+    type,
+    legacyType: options.legacyType,
+    schemaVersion: 1,
+    source: { plugin: "nats-eventstore" },
+    actor: {
+      agentId: agent === "system" ? undefined : agent,
+      userId: firstString(ctx.senderId),
+      channel: firstString(ctx.channelId),
+    },
+    scope: {
+      sessionKey: firstString(ctx.sessionKey),
+      sessionId: firstString(ctx.sessionId),
+      runId: firstString(ctx.runId, payload.runId),
+      toolCallId: firstString(payload.toolCallId),
+      messageId: firstString(ctx.messageId, payload.messageId),
+      jobId: firstString(ctx.jobId),
+    },
+    trace: {
+      traceId: firstString(ctx.traceId, trace.traceId),
+      spanId: firstString(ctx.spanId, trace.spanId),
+      parentSpanId: firstString(ctx.parentSpanId, trace.parentSpanId),
+      causationId: firstString(payload.causationId),
+      correlationId: firstString(ctx.runId, ctx.sessionId, ctx.sessionKey),
+    },
+    visibility: options.visibility ?? "internal",
+    redaction: options.redaction,
+    payload,
+  };
+}
+
 /** Fire-and-forget publish of a ClawEvent to NATS. */
 function publish(
   getClient: () => NatsClient | null,
@@ -38,18 +109,12 @@ function publish(
   session: string,
   payload: Record<string, unknown>,
   logger: PluginLogger,
+  options: PublishOptions = {},
 ): void {
   const client = getClient();
   if (!client?.isConnected()) return;
 
-  const event: ClawEvent = {
-    id: randomUUID(),
-    ts: Date.now(),
-    agent,
-    session,
-    type,
-    payload,
-  };
+  const event = buildEnvelope(type, agent, session, payload, options);
 
   const subject = buildSubject(config.subjectPrefix, agent, type);
   client.publish(subject, JSON.stringify(event)).catch((err) => {
@@ -60,10 +125,14 @@ function publish(
 // ── Hook-to-event mapping table ──
 
 type PayloadMapper = (event: any, ctx: any) => Record<string, unknown>;
+type EventTypeMapper = EventType | ((event: any, ctx: any) => EventType);
 
 type HookMapping = {
   hookName: string;
-  eventType: EventType;
+  eventType: EventTypeMapper;
+  legacyType?: EventType;
+  visibility?: Visibility;
+  redaction?: ClawEvent["redaction"];
   mapper: PayloadMapper;
   /** If true, uses "system" as agent/session (gateway hooks). */
   systemEvent?: boolean;
@@ -72,7 +141,10 @@ type HookMapping = {
 /** Additional events to emit from the same hook (e.g. run.error from agent_end). */
 type ExtraEmitter = {
   hookName: string;
-  eventType: EventType;
+  eventType: EventTypeMapper;
+  legacyType?: EventType;
+  visibility?: Visibility;
+  redaction?: ClawEvent["redaction"];
   condition: (event: any) => boolean;
   mapper: PayloadMapper;
 };
@@ -80,7 +152,9 @@ type ExtraEmitter = {
 const HOOK_MAPPINGS: HookMapping[] = [
   {
     hookName: "message_received",
-    eventType: "msg.in",
+    eventType: "message.in.received",
+    legacyType: "msg.in",
+    visibility: "confidential",
     mapper: (event, ctx) => ({
       from: event.from,
       content: event.content,
@@ -91,7 +165,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "message_sending",
-    eventType: "msg.sending",
+    eventType: "message.out.sending",
+    legacyType: "msg.sending",
+    visibility: "confidential",
     mapper: (event, ctx) => ({
       to: event.to,
       content: event.content,
@@ -100,7 +176,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "message_sent",
-    eventType: "msg.out",
+    eventType: "message.out.sent",
+    legacyType: "msg.out",
+    visibility: "confidential",
     mapper: (event, ctx) => ({
       to: event.to,
       content: event.content,
@@ -111,7 +189,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "before_tool_call",
-    eventType: "tool.call",
+    eventType: "tool.call.requested",
+    legacyType: "tool.call",
+    visibility: "confidential",
     mapper: (event) => ({
       toolName: event.toolName,
       params: event.params,
@@ -119,7 +199,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "after_tool_call",
-    eventType: "tool.result",
+    eventType: (event) => event.error ? "tool.call.failed" : "tool.call.executed",
+    legacyType: "tool.result",
+    visibility: "confidential",
     mapper: (event) => ({
       toolName: event.toolName,
       params: event.params,
@@ -130,12 +212,15 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "before_agent_start",
-    eventType: "run.start",
+    eventType: "run.started",
+    legacyType: "run.start",
+    visibility: "confidential",
     mapper: (event) => ({ prompt: event.prompt }),
   },
   {
     hookName: "agent_end",
-    eventType: "run.end",
+    eventType: "run.ended",
+    legacyType: "run.end",
     mapper: (event) => ({
       success: event.success,
       error: event.error,
@@ -145,7 +230,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "llm_input",
-    eventType: "llm.input",
+    eventType: "model.input.observed",
+    legacyType: "llm.input",
+    redaction: { applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] },
     mapper: (event) => ({
       runId: event.runId,
       sessionId: event.sessionId,
@@ -159,7 +246,9 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "llm_output",
-    eventType: "llm.output",
+    eventType: "model.output.observed",
+    legacyType: "llm.output",
+    redaction: { applied: true, omittedFields: ["assistantTexts"] },
     mapper: (event) => {
       const texts = event.assistantTexts ?? [];
       return {
@@ -178,7 +267,8 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "before_compaction",
-    eventType: "session.compaction_start",
+    eventType: "session.compaction.started",
+    legacyType: "session.compaction_start",
     mapper: (event) => ({
       messageCount: event.messageCount,
       compactingCount: event.compactingCount,
@@ -187,7 +277,8 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "after_compaction",
-    eventType: "session.compaction_end",
+    eventType: "session.compaction.ended",
+    legacyType: "session.compaction_end",
     mapper: (event) => ({
       messageCount: event.messageCount,
       compactedCount: event.compactedCount,
@@ -201,7 +292,8 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "session_start",
-    eventType: "session.start",
+    eventType: "session.started",
+    legacyType: "session.start",
     mapper: (event) => ({
       sessionId: event.sessionId,
       resumedFrom: event.resumedFrom,
@@ -209,7 +301,8 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "session_end",
-    eventType: "session.end",
+    eventType: "session.ended",
+    legacyType: "session.end",
     mapper: (event) => ({
       sessionId: event.sessionId,
       messageCount: event.messageCount,
@@ -218,13 +311,15 @@ const HOOK_MAPPINGS: HookMapping[] = [
   },
   {
     hookName: "gateway_start",
-    eventType: "gateway.start",
+    eventType: "gateway.started",
+    legacyType: "gateway.start",
     mapper: (event) => ({ port: event.port }),
     systemEvent: true,
   },
   {
     hookName: "gateway_stop",
-    eventType: "gateway.stop",
+    eventType: "gateway.stopped",
+    legacyType: "gateway.stop",
     mapper: (event) => ({ reason: event.reason }),
     systemEvent: true,
   },
@@ -234,7 +329,8 @@ const HOOK_MAPPINGS: HookMapping[] = [
 const EXTRA_EMITTERS: ExtraEmitter[] = [
   {
     hookName: "agent_end",
-    eventType: "run.error",
+    eventType: "run.failed",
+    legacyType: "run.error",
     condition: (event) => !event.success,
     mapper: (event) => ({
       success: false,
@@ -260,11 +356,15 @@ export function registerEventHooks(
     type: EventType,
     ctx: HookCtx,
     payload: Record<string, unknown>,
+    options: PublishOptions = {},
   ) => {
     const agent = extractAgentId(ctx);
     const session = ctx.sessionKey ?? ctx.sessionId ?? "unknown";
-    publish(getClient, config, type, agent, session, payload, logger);
+    publish(getClient, config, type, agent, session, payload, logger, { ...options, ctx });
   };
+
+  const resolveEventType = (mapper: EventTypeMapper, event: any, ctx: any): EventType =>
+    typeof mapper === "function" ? mapper(event, ctx) : mapper;
 
   // Build lookup for extra emitters per hook
   const extrasByHook = new Map<string, ExtraEmitter[]>();
@@ -284,16 +384,29 @@ export function registerEventHooks(
       try {
         const payload = mapping.mapper(event, ctx);
 
+        const eventType = resolveEventType(mapping.eventType, event, ctx);
+        const options: PublishOptions = {
+          legacyType: mapping.legacyType,
+          visibility: mapping.visibility,
+          redaction: mapping.redaction,
+          ctx,
+        };
+
         if (mapping.systemEvent) {
-          publish(getClient, config, mapping.eventType, "system", "system", payload, logger);
+          publish(getClient, config, eventType, "system", "system", payload, logger, options);
         } else {
-          pub(mapping.eventType, ctx, payload);
+          pub(eventType, ctx, payload, options);
         }
 
         // Emit any extra events for this hook
         for (const extra of extras) {
           if (extra.condition(event)) {
-            pub(extra.eventType, ctx, extra.mapper(event, ctx));
+            const extraType = resolveEventType(extra.eventType, event, ctx);
+            pub(extraType, ctx, extra.mapper(event, ctx), {
+              legacyType: extra.legacyType,
+              visibility: extra.visibility,
+              redaction: extra.redaction,
+            });
           }
         }
       } catch (err) {

--- a/packages/openclaw-nats-eventstore/src/hooks.ts
+++ b/packages/openclaw-nats-eventstore/src/hooks.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { NatsClient } from "./nats-client.js";
 import type { PluginLogger } from "./nats-client.js";
 import type { NatsEventStoreConfig } from "./config.js";
@@ -46,6 +46,7 @@ type PublishOptions = {
   visibility?: Visibility;
   redaction?: ClawEvent["redaction"];
   ctx?: HookCtx;
+  originalEvent?: Record<string, unknown>;
 };
 
 function firstString(...values: unknown[]): string | undefined {
@@ -55,22 +56,57 @@ function firstString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+function deriveEventId(
+  canonicalType: EventType,
+  session: string,
+  payload: Record<string, unknown>,
+  ctx: HookCtx,
+): string {
+  const originalEvent = (ctx as HookCtx & { originalEvent?: Record<string, unknown> }).originalEvent ?? {};
+  const stableSourceId = firstString(
+    ctx.runId,
+    payload.runId,
+    originalEvent.runId,
+    ctx.messageId,
+    payload.messageId,
+    originalEvent.messageId,
+    payload.toolCallId,
+    originalEvent.toolCallId,
+    ctx.jobId,
+    payload.jobId,
+    originalEvent.jobId,
+    originalEvent.id,
+  );
+
+  if (stableSourceId) {
+    const hash = createHash("sha256")
+      .update(`${session}:${canonicalType}:${stableSourceId}`)
+      .digest("hex")
+      .slice(0, 16);
+    return `evt-${hash}`;
+  }
+
+  return randomUUID();
+}
+
 function buildEnvelope(
-  type: EventType,
+  canonicalType: EventType,
   agent: string,
   session: string,
   payload: Record<string, unknown>,
   options: PublishOptions = {},
 ): ClawEvent {
-  const ctx = options.ctx ?? {};
+  const ctx = { ...(options.ctx ?? {}), originalEvent: options.originalEvent };
   const trace = ctx.trace ?? {};
+  const legacyType = options.legacyType ?? canonicalType;
 
   return {
-    id: randomUUID(),
+    id: deriveEventId(canonicalType, session, payload, ctx),
     ts: Date.now(),
     agent,
     session,
-    type,
+    type: legacyType,
+    canonicalType,
     legacyType: options.legacyType,
     schemaVersion: 1,
     source: { plugin: "nats-eventstore" },
@@ -116,7 +152,7 @@ function publish(
 
   const event = buildEnvelope(type, agent, session, payload, options);
 
-  const subject = buildSubject(config.subjectPrefix, agent, type);
+  const subject = buildSubject(config.subjectPrefix, agent, event.type);
   client.publish(subject, JSON.stringify(event)).catch((err) => {
     logger.warn(`[nats-eventstore] Publish ${type} failed: ${err}`);
   });
@@ -390,6 +426,7 @@ export function registerEventHooks(
           visibility: mapping.visibility,
           redaction: mapping.redaction,
           ctx,
+          originalEvent: event,
         };
 
         if (mapping.systemEvent) {
@@ -406,6 +443,7 @@ export function registerEventHooks(
               legacyType: extra.legacyType,
               visibility: extra.visibility,
               redaction: extra.redaction,
+              originalEvent: event,
             });
           }
         }

--- a/packages/openclaw-nats-eventstore/src/hooks.ts
+++ b/packages/openclaw-nats-eventstore/src/hooks.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { NatsClient } from "./nats-client.js";
 import type { PluginLogger } from "./nats-client.js";
 import type { NatsEventStoreConfig } from "./config.js";
-import type { ClawEvent, EventType, Visibility } from "./events.js";
+import type { ClawEvent, EventType, CanonicalEventType, LegacyEventType, Visibility } from "./events.js";
 import { extractAgentId, buildSubject } from "./util.js";
 import {
   HOOK_MAPPINGS,
@@ -29,6 +29,7 @@ type HookCtx = {
     spanId?: string;
     parentSpanId?: string;
   };
+  originalEvent?: Record<string, unknown>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,7 +50,7 @@ function shouldPublish(hookName: string, config: NatsEventStoreConfig): boolean 
 }
 
 type PublishOptions = {
-  legacyType?: EventType;
+  legacyType?: LegacyEventType;
   visibility?: Visibility;
   redaction?: ClawEvent["redaction"];
   ctx?: HookCtx;
@@ -64,7 +65,7 @@ function firstString(...values: unknown[]): string | undefined {
 }
 
 function deriveEventId(
-  canonicalType: EventType,
+  canonicalType: CanonicalEventType,
   session: string,
   payload: Record<string, unknown>,
   ctx: HookCtx,
@@ -105,28 +106,30 @@ function buildActor(agent: string, ctx: HookCtx): ClawEvent["actor"] {
 }
 
 function buildScope(payload: Record<string, unknown>, ctx: HookCtx): ClawEvent["scope"] {
+  const oe = ctx.originalEvent ?? {};
   return {
-    sessionKey: firstString(ctx.sessionKey),
-    sessionId: firstString(ctx.sessionId),
-    runId: firstString(ctx.runId, payload.runId),
-    toolCallId: firstString(payload.toolCallId),
-    messageId: firstString(ctx.messageId, payload.messageId),
-    jobId: firstString(ctx.jobId),
+    sessionKey: firstString(ctx.sessionKey, oe.sessionKey),
+    sessionId: firstString(ctx.sessionId, oe.sessionId),
+    runId: firstString(ctx.runId, payload.runId, oe.runId),
+    toolCallId: firstString(payload.toolCallId, oe.toolCallId),
+    messageId: firstString(ctx.messageId, payload.messageId, oe.messageId),
+    jobId: firstString(ctx.jobId, payload.jobId, oe.jobId),
   };
 }
 
 function buildTrace(payload: Record<string, unknown>, ctx: HookCtx, trace: any): ClawEvent["trace"] {
+  const oe = ctx.originalEvent ?? {};
   return {
-    traceId: firstString(ctx.traceId, trace.traceId),
-    spanId: firstString(ctx.spanId, trace.spanId),
-    parentSpanId: firstString(ctx.parentSpanId, trace.parentSpanId),
-    causationId: firstString(payload.causationId),
-    correlationId: firstString(ctx.runId, ctx.sessionId, ctx.sessionKey),
+    traceId: firstString(ctx.traceId, trace.traceId, oe.traceId),
+    spanId: firstString(ctx.spanId, trace.spanId, oe.spanId),
+    parentSpanId: firstString(ctx.parentSpanId, trace.parentSpanId, oe.parentSpanId),
+    causationId: firstString(payload.causationId, oe.causationId),
+    correlationId: firstString(ctx.runId, ctx.sessionId, ctx.sessionKey, oe.runId, oe.sessionId, oe.sessionKey),
   };
 }
 
 function buildEnvelope(
-  canonicalType: EventType,
+  canonicalType: CanonicalEventType,
   agent: string,
   session: string,
   payload: Record<string, unknown>,
@@ -134,7 +137,7 @@ function buildEnvelope(
 ): ClawEvent {
   const ctx = { ...(options.ctx ?? {}), originalEvent: options.originalEvent };
   const trace = ctx.trace ?? {};
-  const legacyType = options.legacyType ?? canonicalType;
+  const legacyType = options.legacyType ?? (canonicalType as unknown as EventType);
 
   return {
     id: deriveEventId(canonicalType, session, payload, ctx),
@@ -159,7 +162,7 @@ function buildEnvelope(
 function publish(
   getClient: () => NatsClient | null,
   config: NatsEventStoreConfig,
-  type: EventType,
+  type: CanonicalEventType,
   agent: string,
   session: string,
   payload: Record<string, unknown>,
@@ -177,7 +180,7 @@ function publish(
   });
 }
 
-function resolveEventType(mapper: EventTypeMapper, event: any, ctx: any): EventType {
+function resolveEventType(mapper: EventTypeMapper, event: any, ctx: any): CanonicalEventType {
   return typeof mapper === "function" ? mapper(event, ctx) : mapper;
 }
 
@@ -185,7 +188,7 @@ function emitExtras(
   extras: ExtraEmitter[],
   event: any,
   ctx: any,
-  pub: (type: EventType, ctxPayload: HookCtx, payload: Record<string, unknown>, options?: PublishOptions) => void
+  pub: (type: CanonicalEventType, ctxPayload: HookCtx, payload: Record<string, unknown>, options?: PublishOptions) => void
 ): void {
   for (const extra of extras) {
     if (extra.condition(event)) {
@@ -206,7 +209,7 @@ function publishHookResult(
   logger: PluginLogger
 ) {
   return (
-    type: EventType,
+    type: CanonicalEventType,
     ctxPayload: HookCtx,
     payload: Record<string, unknown>,
     options: PublishOptions = {},

--- a/packages/openclaw-nats-eventstore/test/events.test.ts
+++ b/packages/openclaw-nats-eventstore/test/events.test.ts
@@ -73,7 +73,8 @@ describe("ClawEvent structure", () => {
       ts: Date.now(),
       agent: "main",
       session: "main:matrix:albert",
-      type: "message.in.received",
+      type: "msg.in",
+      canonicalType: "message.in.received",
       legacyType: "msg.in",
       schemaVersion: 1,
       source: { plugin: "nats-eventstore" },
@@ -88,7 +89,8 @@ describe("ClawEvent structure", () => {
     expect(typeof event.ts).toBe("number");
     expect(event.agent).toBe("main");
     expect(event.session).toBe("main:matrix:albert");
-    expect(event.type).toBe("message.in.received");
+    expect(event.type).toBe("msg.in");
+    expect(event.canonicalType).toBe("message.in.received");
     expect(event.legacyType).toBe("msg.in");
     expect(event.payload).toHaveProperty("from");
     expect(event.payload).toHaveProperty("content");

--- a/packages/openclaw-nats-eventstore/test/events.test.ts
+++ b/packages/openclaw-nats-eventstore/test/events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ALL_EVENT_TYPES } from "../src/events.js";
+import { ALL_EVENT_TYPES, CANONICAL_EVENT_TYPES } from "../src/events.js";
 import type { ClawEvent, EventType } from "../src/events.js";
 
 describe("EventType", () => {
@@ -43,18 +43,7 @@ describe("EventType", () => {
 
 
   it("includes Brainplex nervous-system canonical event types", () => {
-    const canonical: EventType[] = [
-      "message.in.received",
-      "message.out.sent",
-      "tool.call.requested",
-      "tool.call.executed",
-      "tool.call.failed",
-      "run.started",
-      "run.ended",
-      "model.input.observed",
-      "model.output.observed",
-      "gateway.started",
-    ];
+    const canonical: EventType[] = [...CANONICAL_EVENT_TYPES];
     for (const t of canonical) {
       expect(ALL_EVENT_TYPES).toContain(t);
     }

--- a/packages/openclaw-nats-eventstore/test/events.test.ts
+++ b/packages/openclaw-nats-eventstore/test/events.test.ts
@@ -3,8 +3,8 @@ import { ALL_EVENT_TYPES } from "../src/events.js";
 import type { ClawEvent, EventType } from "../src/events.js";
 
 describe("EventType", () => {
-  it("has 17 event types", () => {
-    expect(ALL_EVENT_TYPES).toHaveLength(17);
+  it("has 34 event types including canonical and legacy aliases", () => {
+    expect(ALL_EVENT_TYPES).toHaveLength(34);
   });
 
   it("includes all core event types from PR #18171", () => {
@@ -22,7 +22,7 @@ describe("EventType", () => {
     }
   });
 
-  it("includes new plugin event types", () => {
+  it("includes legacy plugin event types", () => {
     const newTypes: EventType[] = [
       "msg.sending",
       "llm.input",
@@ -40,6 +40,26 @@ describe("EventType", () => {
     }
   });
 
+
+
+  it("includes Brainplex nervous-system canonical event types", () => {
+    const canonical: EventType[] = [
+      "message.in.received",
+      "message.out.sent",
+      "tool.call.requested",
+      "tool.call.executed",
+      "tool.call.failed",
+      "run.started",
+      "run.ended",
+      "model.input.observed",
+      "model.output.observed",
+      "gateway.started",
+    ];
+    for (const t of canonical) {
+      expect(ALL_EVENT_TYPES).toContain(t);
+    }
+  });
+
   it("has no duplicate event types", () => {
     const unique = new Set(ALL_EVENT_TYPES);
     expect(unique.size).toBe(ALL_EVENT_TYPES.length);
@@ -53,7 +73,14 @@ describe("ClawEvent structure", () => {
       ts: Date.now(),
       agent: "main",
       session: "main:matrix:albert",
-      type: "msg.in",
+      type: "message.in.received",
+      legacyType: "msg.in",
+      schemaVersion: 1,
+      source: { plugin: "nats-eventstore" },
+      actor: { agentId: "main", channel: "matrix" },
+      scope: { sessionKey: "main:matrix:albert" },
+      trace: { correlationId: "main:matrix:albert" },
+      visibility: "confidential",
       payload: { from: "albert", content: "hello" },
     };
 
@@ -61,7 +88,8 @@ describe("ClawEvent structure", () => {
     expect(typeof event.ts).toBe("number");
     expect(event.agent).toBe("main");
     expect(event.session).toBe("main:matrix:albert");
-    expect(event.type).toBe("msg.in");
+    expect(event.type).toBe("message.in.received");
+    expect(event.legacyType).toBe("msg.in");
     expect(event.payload).toHaveProperty("from");
     expect(event.payload).toHaveProperty("content");
   });
@@ -74,6 +102,12 @@ describe("ClawEvent structure", () => {
         agent: "main",
         session: "main",
         type,
+        schemaVersion: 1,
+        source: { plugin: "nats-eventstore" },
+        actor: { agentId: "main" },
+        scope: { sessionKey: "main" },
+        trace: {},
+        visibility: "internal",
         payload: {},
       };
       expect(event.type).toBe(type);

--- a/packages/openclaw-nats-eventstore/test/events.test.ts
+++ b/packages/openclaw-nats-eventstore/test/events.test.ts
@@ -72,23 +72,23 @@ describe("ClawEvent structure", () => {
       id: "test-uuid",
       ts: Date.now(),
       agent: "main",
-      session: "main:matrix:albert",
+      session: "main:matrix:testuser",
       type: "msg.in",
       canonicalType: "message.in.received",
       legacyType: "msg.in",
       schemaVersion: 1,
       source: { plugin: "nats-eventstore" },
       actor: { agentId: "main", channel: "matrix" },
-      scope: { sessionKey: "main:matrix:albert" },
-      trace: { correlationId: "main:matrix:albert" },
+      scope: { sessionKey: "main:matrix:testuser" },
+      trace: { correlationId: "main:matrix:testuser" },
       visibility: "confidential",
-      payload: { from: "albert", content: "hello" },
+      payload: { from: "testuser", content: "hello" },
     };
 
     expect(event.id).toBe("test-uuid");
     expect(typeof event.ts).toBe("number");
     expect(event.agent).toBe("main");
-    expect(event.session).toBe("main:matrix:albert");
+    expect(event.session).toBe("main:matrix:testuser");
     expect(event.type).toBe("msg.in");
     expect(event.canonicalType).toBe("message.in.received");
     expect(event.legacyType).toBe("msg.in");

--- a/packages/openclaw-nats-eventstore/test/helpers.ts
+++ b/packages/openclaw-nats-eventstore/test/helpers.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+import { DEFAULTS } from "../src/config.js";
+import type { NatsEventStoreConfig } from "../src/config.js";
+import type { NatsClient } from "../src/nats-client.js";
+
+export function defaultConfig(overrides?: Partial<NatsEventStoreConfig>): NatsEventStoreConfig {
+  return { ...DEFAULTS, ...overrides };
+}
+
+export function createMockClient(overrides?: Partial<NatsClient>): NatsClient {
+  return {
+    publish: vi.fn(async () => {}),
+    isConnected: () => true,
+    getStatus: () => ({ connected: true, stream: "test", disconnectCount: 0, publishFailures: 0 }),
+    drain: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+export function createMockApi() {
+  const handlers: Record<string, ((...args: any[]) => void)[]> = {};
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    on: vi.fn((name: string, handler: (...args: any[]) => void) => {
+      (handlers[name] ??= []).push(handler);
+    }),
+    _fire(name: string, ...args: any[]) {
+      for (const h of handlers[name] ?? []) {
+        h(...args);
+      }
+    },
+    _handlers: handlers,
+  };
+}

--- a/packages/openclaw-nats-eventstore/test/helpers.ts
+++ b/packages/openclaw-nats-eventstore/test/helpers.ts
@@ -19,13 +19,13 @@ export function createMockClient(overrides?: Partial<NatsClient>): NatsClient {
 }
 
 export function createMockApi() {
-  const handlers: Record<string, ((...args: any[]) => void)[]> = {};
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-    on: vi.fn((name: string, handler: (...args: any[]) => void) => {
+    on: vi.fn((name: string, handler: (...args: unknown[]) => void) => {
       (handlers[name] ??= []).push(handler);
     }),
-    _fire(name: string, ...args: any[]) {
+    _fire(name: string, ...args: unknown[]) {
       for (const h of handlers[name] ?? []) {
         h(...args);
       }

--- a/packages/openclaw-nats-eventstore/test/hook-mappings.test.ts
+++ b/packages/openclaw-nats-eventstore/test/hook-mappings.test.ts
@@ -122,7 +122,7 @@ describe("Event Hook Mappings", () => {
     expect(event.payload.params).toEqual({ query: "weather" });
   });
 
-  it("maps after_tool_call to tool.result", () => {
+  it("maps after_tool_call to tool.result and canonicalType tool.call.executed on success", () => {
     registerEventHooks(mockApi, defaultConfig(), () => mockClient);
 
     mockApi._fire(
@@ -137,6 +137,23 @@ describe("Event Hook Mappings", () => {
     expect(event.canonicalType).toBe("tool.call.executed");
     expect(event.legacyType).toBe("tool.result");
     expect(event.payload.durationMs).toBe(500);
+  });
+
+  it("maps after_tool_call to tool.result and canonicalType tool.call.failed on error", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "after_tool_call",
+      { toolName: "web_search", params: { query: "weather" }, result: null, error: "Network Error", durationMs: 500 },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("tool.result");
+    expect(event.canonicalType).toBe("tool.call.failed");
+    expect(event.legacyType).toBe("tool.result");
+    expect(event.payload.error).toBe("Network Error");
   });
 
   it("maps before_agent_start to run.start", () => {

--- a/packages/openclaw-nats-eventstore/test/hook-mappings.test.ts
+++ b/packages/openclaw-nats-eventstore/test/hook-mappings.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerEventHooks } from "../src/hooks.js";
+import type { NatsClient } from "../src/nats-client.js";
+import { defaultConfig, createMockApi, createMockClient } from "./helpers.js";
+
+describe("Event Hook Mappings", () => {
+  let mockApi: ReturnType<typeof createMockApi>;
+  let mockClient: NatsClient;
+  let published: Array<{ subject: string; data: string }>;
+
+  beforeEach(() => {
+    published = [];
+    mockApi = createMockApi();
+    mockClient = createMockClient({
+      publish: vi.fn(async (subject: string, data: string) => {
+        published.push({ subject, data });
+      }),
+    });
+  });
+
+  it("registers handlers for all 16 hooks", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    const expectedHooks = [
+      "message_received", "message_sending", "message_sent",
+      "before_tool_call", "after_tool_call",
+      "before_agent_start", "agent_end",
+      "llm_input", "llm_output",
+      "before_compaction", "after_compaction",
+      "before_reset",
+      "session_start", "session_end",
+      "gateway_start", "gateway_stop",
+    ];
+
+    for (const hook of expectedHooks) {
+      expect(mockApi._handlers[hook], `Handler for ${hook} should be registered`).toBeDefined();
+      expect(mockApi._handlers[hook]!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps message_received to msg.in", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "message_received",
+      { from: "testuser", content: "hello", timestamp: 1000, metadata: { key: "val" } },
+      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    expect(published[0].subject).toBe("openclaw.events.main.msg_in");
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("msg.in");
+    expect(event.canonicalType).toBe("message.in.received");
+    expect(event.legacyType).toBe("msg.in");
+    expect(event.schemaVersion).toBe(1);
+    expect(event.source.plugin).toBe("nats-eventstore");
+    expect(event.actor.agentId).toBe("main");
+    expect(event.actor.channel).toBe("matrix");
+    expect(event.scope.sessionKey).toBe("main:matrix:testuser");
+    expect(event.visibility).toBe("confidential");
+    expect(event.agent).toBe("main");
+    expect(event.session).toBe("main:matrix:testuser");
+    expect(event.payload.from).toBe("testuser");
+    expect(event.payload.content).toBe("hello");
+    expect(event.payload.channel).toBe("matrix");
+    expect(event.payload.metadata).toEqual({ key: "val" });
+    expect(event.id).toBeDefined();
+    expect(event.ts).toBeGreaterThan(0);
+  });
+
+  it("maps message_sending to msg.sending", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "message_sending",
+      { to: "testuser", content: "Hi!" },
+      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("msg.sending");
+    expect(event.canonicalType).toBe("message.out.sending");
+    expect(event.legacyType).toBe("msg.sending");
+    expect(event.payload.to).toBe("testuser");
+    expect(event.payload.content).toBe("Hi!");
+  });
+
+  it("maps message_sent to msg.out", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "message_sent",
+      { to: "testuser", content: "Hi!", success: true, error: null },
+      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("msg.out");
+    expect(event.canonicalType).toBe("message.out.sent");
+    expect(event.legacyType).toBe("msg.out");
+    expect(event.payload.success).toBe(true);
+  });
+
+  it("maps before_tool_call to tool.call", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "before_tool_call",
+      { toolName: "web_search", params: { query: "weather" } },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("tool.call");
+    expect(event.canonicalType).toBe("tool.call.requested");
+    expect(event.legacyType).toBe("tool.call");
+    expect(event.payload.toolName).toBe("web_search");
+    expect(event.payload.params).toEqual({ query: "weather" });
+  });
+
+  it("maps after_tool_call to tool.result", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "after_tool_call",
+      { toolName: "web_search", params: { query: "weather" }, result: "sunny", error: null, durationMs: 500 },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("tool.result");
+    expect(event.canonicalType).toBe("tool.call.executed");
+    expect(event.legacyType).toBe("tool.result");
+    expect(event.payload.durationMs).toBe(500);
+  });
+
+  it("maps before_agent_start to run.start", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "before_agent_start",
+      { prompt: "Hello Claudia" },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("run.start");
+    expect(event.canonicalType).toBe("run.started");
+    expect(event.legacyType).toBe("run.start");
+    expect(event.payload.prompt).toBe("Hello Claudia");
+  });
+
+  it("emits both run.end and run.error on failure", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "agent_end",
+      { success: false, error: "Provider timeout", durationMs: 30000, messages: [1, 2] },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(2);
+    const runEnd = JSON.parse(published[0].data);
+    const runError = JSON.parse(published[1].data);
+
+    expect(runEnd.type).toBe("run.end");
+    expect(runEnd.canonicalType).toBe("run.ended");
+    expect(runEnd.legacyType).toBe("run.end");
+    expect(runEnd.payload.success).toBe(false);
+    expect(runEnd.payload.messageCount).toBe(2);
+
+    expect(runError.type).toBe("run.error");
+    expect(runError.canonicalType).toBe("run.failed");
+    expect(runError.legacyType).toBe("run.error");
+    expect(runError.payload.error).toBe("Provider timeout");
+  });
+
+  it("emits only run.end on success (no run.error)", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "agent_end",
+      { success: true, error: null, durationMs: 5000, messages: [1, 2, 3] },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("run.end");
+    expect(event.canonicalType).toBe("run.ended");
+    expect(event.legacyType).toBe("run.end");
+    expect(event.payload.success).toBe(true);
+    expect(event.payload.messageCount).toBe(3);
+  });
+
+  it("maps llm_input to llm.input with privacy (lengths, not content)", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "llm_input",
+      {
+        runId: "run-1",
+        sessionId: "sess-1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        systemPrompt: "You are a helpful assistant",
+        prompt: "What's the weather?",
+        historyMessages: [1, 2, 3],
+        imagesCount: 0,
+      },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("llm.input");
+    expect(event.canonicalType).toBe("model.input.observed");
+    expect(event.legacyType).toBe("llm.input");
+    expect(event.redaction).toEqual({ applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] });
+    expect(event.payload.systemPromptLength).toBe("You are a helpful assistant".length);
+    expect(event.payload.promptLength).toBe("What's the weather?".length);
+    expect(event.payload.historyMessageCount).toBe(3);
+    // Should NOT include content
+    expect(event.payload.systemPrompt).toBeUndefined();
+    expect(event.payload.prompt).toBeUndefined();
+  });
+
+  it("maps llm_output to llm.output", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "llm_output",
+      {
+        runId: "run-1",
+        sessionId: "sess-1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        assistantTexts: ["Hello!", "How can I help?"],
+        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+      },
+      { agentId: "main", sessionKey: "main:matrix:testuser" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("llm.output");
+    expect(event.canonicalType).toBe("model.output.observed");
+    expect(event.legacyType).toBe("llm.output");
+    expect(event.payload.assistantTextCount).toBe(2);
+    expect(event.payload.assistantTextTotalLength).toBe("Hello!".length + "How can I help?".length);
+    expect(event.payload.usage).toEqual({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 });
+  });
+
+  it("handles llm_output with undefined/null assistantTexts gracefully", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire(
+      "llm_output",
+      {
+        runId: "run-2",
+        sessionId: "sess-2",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        usage: { input: 10, output: 0, total: 10 },
+      },
+      { agentId: "main", sessionKey: "main" },
+    );
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.payload.assistantTextCount).toBe(0);
+    expect(event.payload.assistantTextTotalLength).toBe(0);
+  });
+
+  it("maps gateway_start and gateway_stop with system agent", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire("gateway_start", { port: 3000 });
+    mockApi._fire("gateway_stop", { reason: "SIGTERM" });
+
+    expect(published).toHaveLength(2);
+    const start = JSON.parse(published[0].data);
+    const stop = JSON.parse(published[1].data);
+
+    expect(start.type).toBe("gateway.start");
+    expect(start.canonicalType).toBe("gateway.started");
+    expect(start.legacyType).toBe("gateway.start");
+    expect(start.agent).toBe("system");
+    expect(start.session).toBe("system");
+    expect(start.payload.port).toBe(3000);
+
+    expect(stop.type).toBe("gateway.stop");
+    expect(stop.canonicalType).toBe("gateway.stopped");
+    expect(stop.legacyType).toBe("gateway.stop");
+    expect(stop.agent).toBe("system");
+    expect(stop.payload.reason).toBe("SIGTERM");
+  });
+
+  it("maps session hooks correctly", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire("session_start", { sessionId: "s1", resumedFrom: null }, { agentId: "main", sessionKey: "main" });
+    mockApi._fire("session_end", { sessionId: "s1", messageCount: 42, durationMs: 5000 }, { agentId: "main", sessionKey: "main" });
+
+    expect(published).toHaveLength(2);
+    expect(JSON.parse(published[0].data).type).toBe("session.start");
+    expect(JSON.parse(published[0].data).canonicalType).toBe("session.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.end");
+    expect(JSON.parse(published[1].data).canonicalType).toBe("session.ended");
+  });
+
+  it("maps compaction hooks correctly", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire("before_compaction", { messageCount: 200, compactingCount: 150, tokenCount: 45000 }, { agentId: "main", sessionKey: "main" });
+    mockApi._fire("after_compaction", { messageCount: 200, compactedCount: 5, tokenCount: 8000 }, { agentId: "main", sessionKey: "main" });
+
+    expect(published).toHaveLength(2);
+    expect(JSON.parse(published[0].data).type).toBe("session.compaction_start");
+    expect(JSON.parse(published[0].data).canonicalType).toBe("session.compaction.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.compaction_end");
+    expect(JSON.parse(published[1].data).canonicalType).toBe("session.compaction.ended");
+  });
+
+  it("maps before_reset to session.reset", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire("before_reset", { reason: "/new" }, { agentId: "main", sessionKey: "main" });
+
+    expect(published).toHaveLength(1);
+    const event = JSON.parse(published[0].data);
+    expect(event.type).toBe("session.reset");
+    expect(event.payload.reason).toBe("/new");
+  });
+});

--- a/packages/openclaw-nats-eventstore/test/hooks.test.ts
+++ b/packages/openclaw-nats-eventstore/test/hooks.test.ts
@@ -80,9 +80,16 @@ describe("registerEventHooks", () => {
     );
 
     expect(published).toHaveLength(1);
-    expect(published[0].subject).toBe("openclaw.events.main.msg_in");
+    expect(published[0].subject).toBe("openclaw.events.main.message_in_received");
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.in");
+    expect(event.type).toBe("message.in.received");
+    expect(event.legacyType).toBe("msg.in");
+    expect(event.schemaVersion).toBe(1);
+    expect(event.source.plugin).toBe("nats-eventstore");
+    expect(event.actor.agentId).toBe("main");
+    expect(event.actor.channel).toBe("matrix");
+    expect(event.scope.sessionKey).toBe("main:matrix:albert");
+    expect(event.visibility).toBe("confidential");
     expect(event.agent).toBe("main");
     expect(event.session).toBe("main:matrix:albert");
     expect(event.payload.from).toBe("albert");
@@ -104,7 +111,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.sending");
+    expect(event.type).toBe("message.out.sending");
+    expect(event.legacyType).toBe("msg.sending");
     expect(event.payload.to).toBe("albert");
     expect(event.payload.content).toBe("Hi!");
   });
@@ -120,7 +128,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.out");
+    expect(event.type).toBe("message.out.sent");
+    expect(event.legacyType).toBe("msg.out");
     expect(event.payload.success).toBe(true);
   });
 
@@ -135,7 +144,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.call");
+    expect(event.type).toBe("tool.call.requested");
+    expect(event.legacyType).toBe("tool.call");
     expect(event.payload.toolName).toBe("web_search");
     expect(event.payload.params).toEqual({ query: "weather" });
   });
@@ -151,7 +161,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.result");
+    expect(event.type).toBe("tool.call.executed");
+    expect(event.legacyType).toBe("tool.result");
     expect(event.payload.durationMs).toBe(500);
   });
 
@@ -166,7 +177,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.start");
+    expect(event.type).toBe("run.started");
+    expect(event.legacyType).toBe("run.start");
     expect(event.payload.prompt).toBe("Hello Claudia");
   });
 
@@ -183,11 +195,13 @@ describe("registerEventHooks", () => {
     const runEnd = JSON.parse(published[0].data);
     const runError = JSON.parse(published[1].data);
 
-    expect(runEnd.type).toBe("run.end");
+    expect(runEnd.type).toBe("run.ended");
+    expect(runEnd.legacyType).toBe("run.end");
     expect(runEnd.payload.success).toBe(false);
     expect(runEnd.payload.messageCount).toBe(2);
 
-    expect(runError.type).toBe("run.error");
+    expect(runError.type).toBe("run.failed");
+    expect(runError.legacyType).toBe("run.error");
     expect(runError.payload.error).toBe("Provider timeout");
   });
 
@@ -202,7 +216,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.end");
+    expect(event.type).toBe("run.ended");
+    expect(event.legacyType).toBe("run.end");
     expect(event.payload.success).toBe(true);
     expect(event.payload.messageCount).toBe(3);
   });
@@ -227,7 +242,9 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("llm.input");
+    expect(event.type).toBe("model.input.observed");
+    expect(event.legacyType).toBe("llm.input");
+    expect(event.redaction).toEqual({ applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] });
     expect(event.payload.systemPromptLength).toBe("You are a helpful assistant".length);
     expect(event.payload.promptLength).toBe("What's the weather?".length);
     expect(event.payload.historyMessageCount).toBe(3);
@@ -254,7 +271,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("llm.output");
+    expect(event.type).toBe("model.output.observed");
+    expect(event.legacyType).toBe("llm.output");
     expect(event.payload.assistantTextCount).toBe(2);
     expect(event.payload.assistantTextTotalLength).toBe("Hello!".length + "How can I help?".length);
     expect(event.payload.usage).toEqual({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 });
@@ -293,12 +311,14 @@ describe("registerEventHooks", () => {
     const start = JSON.parse(published[0].data);
     const stop = JSON.parse(published[1].data);
 
-    expect(start.type).toBe("gateway.start");
+    expect(start.type).toBe("gateway.started");
+    expect(start.legacyType).toBe("gateway.start");
     expect(start.agent).toBe("system");
     expect(start.session).toBe("system");
     expect(start.payload.port).toBe(3000);
 
-    expect(stop.type).toBe("gateway.stop");
+    expect(stop.type).toBe("gateway.stopped");
+    expect(stop.legacyType).toBe("gateway.stop");
     expect(stop.agent).toBe("system");
     expect(stop.payload.reason).toBe("SIGTERM");
   });
@@ -310,8 +330,8 @@ describe("registerEventHooks", () => {
     mockApi._fire("session_end", { sessionId: "s1", messageCount: 42, durationMs: 5000 }, { agentId: "main", sessionKey: "main" });
 
     expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.start");
-    expect(JSON.parse(published[1].data).type).toBe("session.end");
+    expect(JSON.parse(published[0].data).type).toBe("session.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.ended");
   });
 
   it("maps compaction hooks correctly", () => {
@@ -321,8 +341,8 @@ describe("registerEventHooks", () => {
     mockApi._fire("after_compaction", { messageCount: 200, compactedCount: 5, tokenCount: 8000 }, { agentId: "main", sessionKey: "main" });
 
     expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.compaction_start");
-    expect(JSON.parse(published[1].data).type).toBe("session.compaction_end");
+    expect(JSON.parse(published[0].data).type).toBe("session.compaction.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.compaction.ended");
   });
 
   it("maps before_reset to session.reset", () => {
@@ -394,7 +414,7 @@ describe("registerEventHooks", () => {
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
     expect(event.agent).toBe("viola");
-    expect(published[0].subject).toBe("openclaw.events.viola.msg_in");
+    expect(published[0].subject).toBe("openclaw.events.viola.message_in_received");
   });
 
   it("hook handler errors are caught and do not propagate", () => {

--- a/packages/openclaw-nats-eventstore/test/hooks.test.ts
+++ b/packages/openclaw-nats-eventstore/test/hooks.test.ts
@@ -80,9 +80,10 @@ describe("registerEventHooks", () => {
     );
 
     expect(published).toHaveLength(1);
-    expect(published[0].subject).toBe("openclaw.events.main.message_in_received");
+    expect(published[0].subject).toBe("openclaw.events.main.msg_in");
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("message.in.received");
+    expect(event.type).toBe("msg.in");
+    expect(event.canonicalType).toBe("message.in.received");
     expect(event.legacyType).toBe("msg.in");
     expect(event.schemaVersion).toBe(1);
     expect(event.source.plugin).toBe("nats-eventstore");
@@ -111,7 +112,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("message.out.sending");
+    expect(event.type).toBe("msg.sending");
+    expect(event.canonicalType).toBe("message.out.sending");
     expect(event.legacyType).toBe("msg.sending");
     expect(event.payload.to).toBe("albert");
     expect(event.payload.content).toBe("Hi!");
@@ -128,7 +130,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("message.out.sent");
+    expect(event.type).toBe("msg.out");
+    expect(event.canonicalType).toBe("message.out.sent");
     expect(event.legacyType).toBe("msg.out");
     expect(event.payload.success).toBe(true);
   });
@@ -144,7 +147,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.call.requested");
+    expect(event.type).toBe("tool.call");
+    expect(event.canonicalType).toBe("tool.call.requested");
     expect(event.legacyType).toBe("tool.call");
     expect(event.payload.toolName).toBe("web_search");
     expect(event.payload.params).toEqual({ query: "weather" });
@@ -161,7 +165,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.call.executed");
+    expect(event.type).toBe("tool.result");
+    expect(event.canonicalType).toBe("tool.call.executed");
     expect(event.legacyType).toBe("tool.result");
     expect(event.payload.durationMs).toBe(500);
   });
@@ -177,7 +182,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.started");
+    expect(event.type).toBe("run.start");
+    expect(event.canonicalType).toBe("run.started");
     expect(event.legacyType).toBe("run.start");
     expect(event.payload.prompt).toBe("Hello Claudia");
   });
@@ -195,12 +201,14 @@ describe("registerEventHooks", () => {
     const runEnd = JSON.parse(published[0].data);
     const runError = JSON.parse(published[1].data);
 
-    expect(runEnd.type).toBe("run.ended");
+    expect(runEnd.type).toBe("run.end");
+    expect(runEnd.canonicalType).toBe("run.ended");
     expect(runEnd.legacyType).toBe("run.end");
     expect(runEnd.payload.success).toBe(false);
     expect(runEnd.payload.messageCount).toBe(2);
 
-    expect(runError.type).toBe("run.failed");
+    expect(runError.type).toBe("run.error");
+    expect(runError.canonicalType).toBe("run.failed");
     expect(runError.legacyType).toBe("run.error");
     expect(runError.payload.error).toBe("Provider timeout");
   });
@@ -216,7 +224,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.ended");
+    expect(event.type).toBe("run.end");
+    expect(event.canonicalType).toBe("run.ended");
     expect(event.legacyType).toBe("run.end");
     expect(event.payload.success).toBe(true);
     expect(event.payload.messageCount).toBe(3);
@@ -242,7 +251,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("model.input.observed");
+    expect(event.type).toBe("llm.input");
+    expect(event.canonicalType).toBe("model.input.observed");
     expect(event.legacyType).toBe("llm.input");
     expect(event.redaction).toEqual({ applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] });
     expect(event.payload.systemPromptLength).toBe("You are a helpful assistant".length);
@@ -271,7 +281,8 @@ describe("registerEventHooks", () => {
 
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("model.output.observed");
+    expect(event.type).toBe("llm.output");
+    expect(event.canonicalType).toBe("model.output.observed");
     expect(event.legacyType).toBe("llm.output");
     expect(event.payload.assistantTextCount).toBe(2);
     expect(event.payload.assistantTextTotalLength).toBe("Hello!".length + "How can I help?".length);
@@ -311,13 +322,15 @@ describe("registerEventHooks", () => {
     const start = JSON.parse(published[0].data);
     const stop = JSON.parse(published[1].data);
 
-    expect(start.type).toBe("gateway.started");
+    expect(start.type).toBe("gateway.start");
+    expect(start.canonicalType).toBe("gateway.started");
     expect(start.legacyType).toBe("gateway.start");
     expect(start.agent).toBe("system");
     expect(start.session).toBe("system");
     expect(start.payload.port).toBe(3000);
 
-    expect(stop.type).toBe("gateway.stopped");
+    expect(stop.type).toBe("gateway.stop");
+    expect(stop.canonicalType).toBe("gateway.stopped");
     expect(stop.legacyType).toBe("gateway.stop");
     expect(stop.agent).toBe("system");
     expect(stop.payload.reason).toBe("SIGTERM");
@@ -330,8 +343,10 @@ describe("registerEventHooks", () => {
     mockApi._fire("session_end", { sessionId: "s1", messageCount: 42, durationMs: 5000 }, { agentId: "main", sessionKey: "main" });
 
     expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.started");
-    expect(JSON.parse(published[1].data).type).toBe("session.ended");
+    expect(JSON.parse(published[0].data).type).toBe("session.start");
+    expect(JSON.parse(published[0].data).canonicalType).toBe("session.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.end");
+    expect(JSON.parse(published[1].data).canonicalType).toBe("session.ended");
   });
 
   it("maps compaction hooks correctly", () => {
@@ -341,8 +356,10 @@ describe("registerEventHooks", () => {
     mockApi._fire("after_compaction", { messageCount: 200, compactedCount: 5, tokenCount: 8000 }, { agentId: "main", sessionKey: "main" });
 
     expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.compaction.started");
-    expect(JSON.parse(published[1].data).type).toBe("session.compaction.ended");
+    expect(JSON.parse(published[0].data).type).toBe("session.compaction_start");
+    expect(JSON.parse(published[0].data).canonicalType).toBe("session.compaction.started");
+    expect(JSON.parse(published[1].data).type).toBe("session.compaction_end");
+    expect(JSON.parse(published[1].data).canonicalType).toBe("session.compaction.ended");
   });
 
   it("maps before_reset to session.reset", () => {
@@ -414,7 +431,7 @@ describe("registerEventHooks", () => {
     expect(published).toHaveLength(1);
     const event = JSON.parse(published[0].data);
     expect(event.agent).toBe("viola");
-    expect(published[0].subject).toBe("openclaw.events.viola.message_in_received");
+    expect(published[0].subject).toBe("openclaw.events.viola.msg_in");
   });
 
   it("hook handler errors are caught and do not propagate", () => {
@@ -435,7 +452,7 @@ describe("registerEventHooks", () => {
     }).not.toThrow();
   });
 
-  it("generates unique event IDs", () => {
+  it("generates unique event IDs when no stable source identifiers exist", () => {
     registerEventHooks(mockApi, defaultConfig(), () => mockClient);
 
     mockApi._fire("message_received", { from: "a", content: "1", timestamp: 1 }, { agentId: "main", sessionKey: "main" });
@@ -445,4 +462,29 @@ describe("registerEventHooks", () => {
     const id2 = JSON.parse(published[1].data).id;
     expect(id1).not.toBe(id2);
   });
+
+  it("generates deterministic event IDs when stable source identifiers exist", () => {
+    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
+
+    mockApi._fire("before_agent_start", { prompt: "hi", runId: "run-123" }, { agentId: "main", sessionKey: "sess" });
+    mockApi._fire("before_agent_start", { prompt: "hi", runId: "run-123" }, { agentId: "main", sessionKey: "sess" });
+
+    const runId1 = JSON.parse(published[0].data).id;
+    const runId2 = JSON.parse(published[1].data).id;
+    expect(runId1).toBe(runId2);
+    expect(runId1).toMatch(/^evt-/);
+
+    mockApi._fire("message_received", { from: "u", content: "c", messageId: "msg-999" }, { agentId: "main", sessionKey: "sess" });
+    mockApi._fire("message_received", { from: "u", content: "c", messageId: "msg-999" }, { agentId: "main", sessionKey: "sess" });
+
+    const msgId1 = JSON.parse(published[2].data).id;
+    const msgId2 = JSON.parse(published[3].data).id;
+    expect(msgId1).toBe(msgId2);
+    expect(msgId1).toMatch(/^evt-/);
+
+    mockApi._fire("before_agent_start", { prompt: "hi", runId: "run-456" }, { agentId: "main", sessionKey: "sess" });
+    const runId3 = JSON.parse(published[4].data).id;
+    expect(runId3).not.toBe(runId1);
+  });
 });
+

--- a/packages/openclaw-nats-eventstore/test/hooks.test.ts
+++ b/packages/openclaw-nats-eventstore/test/hooks.test.ts
@@ -1,41 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { registerEventHooks } from "../src/hooks.js";
-import { DEFAULTS } from "../src/config.js";
-import type { NatsEventStoreConfig } from "../src/config.js";
 import type { NatsClient } from "../src/nats-client.js";
+import { defaultConfig, createMockApi, createMockClient } from "./helpers.js";
 
-function defaultConfig(overrides?: Partial<NatsEventStoreConfig>): NatsEventStoreConfig {
-  return { ...DEFAULTS, ...overrides };
-}
-
-function createMockClient(overrides?: Partial<NatsClient>): NatsClient {
-  return {
-    publish: vi.fn(async () => {}),
-    isConnected: () => true,
-    getStatus: () => ({ connected: true, stream: "test", disconnectCount: 0, publishFailures: 0 }),
-    drain: vi.fn(async () => {}),
-    close: vi.fn(async () => {}),
-    ...overrides,
-  };
-}
-
-function createMockApi() {
-  const handlers: Record<string, ((...args: any[]) => void)[]> = {};
-  return {
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-    on: vi.fn((name: string, handler: (...args: any[]) => void) => {
-      (handlers[name] ??= []).push(handler);
-    }),
-    _fire(name: string, ...args: any[]) {
-      for (const h of handlers[name] ?? []) {
-        h(...args);
-      }
-    },
-    _handlers: handlers,
-  };
-}
-
-describe("registerEventHooks", () => {
+describe("Event Hooks Setup & Config", () => {
   let mockApi: ReturnType<typeof createMockApi>;
   let mockClient: NatsClient;
   let published: Array<{ subject: string; data: string }>;
@@ -48,329 +16,6 @@ describe("registerEventHooks", () => {
         published.push({ subject, data });
       }),
     });
-  });
-
-  it("registers handlers for all 16 hooks", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    const expectedHooks = [
-      "message_received", "message_sending", "message_sent",
-      "before_tool_call", "after_tool_call",
-      "before_agent_start", "agent_end",
-      "llm_input", "llm_output",
-      "before_compaction", "after_compaction",
-      "before_reset",
-      "session_start", "session_end",
-      "gateway_start", "gateway_stop",
-    ];
-
-    for (const hook of expectedHooks) {
-      expect(mockApi._handlers[hook], `Handler for ${hook} should be registered`).toBeDefined();
-      expect(mockApi._handlers[hook]!.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("maps message_received to msg.in", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "message_received",
-      { from: "albert", content: "hello", timestamp: 1000, metadata: { key: "val" } },
-      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    expect(published[0].subject).toBe("openclaw.events.main.msg_in");
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.in");
-    expect(event.canonicalType).toBe("message.in.received");
-    expect(event.legacyType).toBe("msg.in");
-    expect(event.schemaVersion).toBe(1);
-    expect(event.source.plugin).toBe("nats-eventstore");
-    expect(event.actor.agentId).toBe("main");
-    expect(event.actor.channel).toBe("matrix");
-    expect(event.scope.sessionKey).toBe("main:matrix:albert");
-    expect(event.visibility).toBe("confidential");
-    expect(event.agent).toBe("main");
-    expect(event.session).toBe("main:matrix:albert");
-    expect(event.payload.from).toBe("albert");
-    expect(event.payload.content).toBe("hello");
-    expect(event.payload.channel).toBe("matrix");
-    expect(event.payload.metadata).toEqual({ key: "val" });
-    expect(event.id).toBeDefined();
-    expect(event.ts).toBeGreaterThan(0);
-  });
-
-  it("maps message_sending to msg.sending", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "message_sending",
-      { to: "albert", content: "Hi!" },
-      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.sending");
-    expect(event.canonicalType).toBe("message.out.sending");
-    expect(event.legacyType).toBe("msg.sending");
-    expect(event.payload.to).toBe("albert");
-    expect(event.payload.content).toBe("Hi!");
-  });
-
-  it("maps message_sent to msg.out", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "message_sent",
-      { to: "albert", content: "Hi!", success: true, error: null },
-      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("msg.out");
-    expect(event.canonicalType).toBe("message.out.sent");
-    expect(event.legacyType).toBe("msg.out");
-    expect(event.payload.success).toBe(true);
-  });
-
-  it("maps before_tool_call to tool.call", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "before_tool_call",
-      { toolName: "web_search", params: { query: "weather" } },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.call");
-    expect(event.canonicalType).toBe("tool.call.requested");
-    expect(event.legacyType).toBe("tool.call");
-    expect(event.payload.toolName).toBe("web_search");
-    expect(event.payload.params).toEqual({ query: "weather" });
-  });
-
-  it("maps after_tool_call to tool.result", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "after_tool_call",
-      { toolName: "web_search", params: { query: "weather" }, result: "sunny", error: null, durationMs: 500 },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("tool.result");
-    expect(event.canonicalType).toBe("tool.call.executed");
-    expect(event.legacyType).toBe("tool.result");
-    expect(event.payload.durationMs).toBe(500);
-  });
-
-  it("maps before_agent_start to run.start", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "before_agent_start",
-      { prompt: "Hello Claudia" },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.start");
-    expect(event.canonicalType).toBe("run.started");
-    expect(event.legacyType).toBe("run.start");
-    expect(event.payload.prompt).toBe("Hello Claudia");
-  });
-
-  it("emits both run.end and run.error on failure", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "agent_end",
-      { success: false, error: "Provider timeout", durationMs: 30000, messages: [1, 2] },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(2);
-    const runEnd = JSON.parse(published[0].data);
-    const runError = JSON.parse(published[1].data);
-
-    expect(runEnd.type).toBe("run.end");
-    expect(runEnd.canonicalType).toBe("run.ended");
-    expect(runEnd.legacyType).toBe("run.end");
-    expect(runEnd.payload.success).toBe(false);
-    expect(runEnd.payload.messageCount).toBe(2);
-
-    expect(runError.type).toBe("run.error");
-    expect(runError.canonicalType).toBe("run.failed");
-    expect(runError.legacyType).toBe("run.error");
-    expect(runError.payload.error).toBe("Provider timeout");
-  });
-
-  it("emits only run.end on success (no run.error)", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "agent_end",
-      { success: true, error: null, durationMs: 5000, messages: [1, 2, 3] },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("run.end");
-    expect(event.canonicalType).toBe("run.ended");
-    expect(event.legacyType).toBe("run.end");
-    expect(event.payload.success).toBe(true);
-    expect(event.payload.messageCount).toBe(3);
-  });
-
-  it("maps llm_input to llm.input with privacy (lengths, not content)", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "llm_input",
-      {
-        runId: "run-1",
-        sessionId: "sess-1",
-        provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
-        systemPrompt: "You are a helpful assistant",
-        prompt: "What's the weather?",
-        historyMessages: [1, 2, 3],
-        imagesCount: 0,
-      },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("llm.input");
-    expect(event.canonicalType).toBe("model.input.observed");
-    expect(event.legacyType).toBe("llm.input");
-    expect(event.redaction).toEqual({ applied: true, omittedFields: ["systemPrompt", "prompt", "historyMessages"] });
-    expect(event.payload.systemPromptLength).toBe("You are a helpful assistant".length);
-    expect(event.payload.promptLength).toBe("What's the weather?".length);
-    expect(event.payload.historyMessageCount).toBe(3);
-    // Should NOT include content
-    expect(event.payload.systemPrompt).toBeUndefined();
-    expect(event.payload.prompt).toBeUndefined();
-  });
-
-  it("maps llm_output to llm.output", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire(
-      "llm_output",
-      {
-        runId: "run-1",
-        sessionId: "sess-1",
-        provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
-        assistantTexts: ["Hello!", "How can I help?"],
-        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
-      },
-      { agentId: "main", sessionKey: "main:matrix:albert" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("llm.output");
-    expect(event.canonicalType).toBe("model.output.observed");
-    expect(event.legacyType).toBe("llm.output");
-    expect(event.payload.assistantTextCount).toBe(2);
-    expect(event.payload.assistantTextTotalLength).toBe("Hello!".length + "How can I help?".length);
-    expect(event.payload.usage).toEqual({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 });
-  });
-
-  it("handles llm_output with undefined/null assistantTexts gracefully", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    // undefined assistantTexts
-    mockApi._fire(
-      "llm_output",
-      {
-        runId: "run-2",
-        sessionId: "sess-2",
-        provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
-        // assistantTexts intentionally omitted
-        usage: { input: 10, output: 0, total: 10 },
-      },
-      { agentId: "main", sessionKey: "main" },
-    );
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.payload.assistantTextCount).toBe(0);
-    expect(event.payload.assistantTextTotalLength).toBe(0);
-  });
-
-  it("maps gateway_start and gateway_stop with system agent", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire("gateway_start", { port: 3000 });
-    mockApi._fire("gateway_stop", { reason: "SIGTERM" });
-
-    expect(published).toHaveLength(2);
-    const start = JSON.parse(published[0].data);
-    const stop = JSON.parse(published[1].data);
-
-    expect(start.type).toBe("gateway.start");
-    expect(start.canonicalType).toBe("gateway.started");
-    expect(start.legacyType).toBe("gateway.start");
-    expect(start.agent).toBe("system");
-    expect(start.session).toBe("system");
-    expect(start.payload.port).toBe(3000);
-
-    expect(stop.type).toBe("gateway.stop");
-    expect(stop.canonicalType).toBe("gateway.stopped");
-    expect(stop.legacyType).toBe("gateway.stop");
-    expect(stop.agent).toBe("system");
-    expect(stop.payload.reason).toBe("SIGTERM");
-  });
-
-  it("maps session hooks correctly", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire("session_start", { sessionId: "s1", resumedFrom: null }, { agentId: "main", sessionKey: "main" });
-    mockApi._fire("session_end", { sessionId: "s1", messageCount: 42, durationMs: 5000 }, { agentId: "main", sessionKey: "main" });
-
-    expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.start");
-    expect(JSON.parse(published[0].data).canonicalType).toBe("session.started");
-    expect(JSON.parse(published[1].data).type).toBe("session.end");
-    expect(JSON.parse(published[1].data).canonicalType).toBe("session.ended");
-  });
-
-  it("maps compaction hooks correctly", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire("before_compaction", { messageCount: 200, compactingCount: 150, tokenCount: 45000 }, { agentId: "main", sessionKey: "main" });
-    mockApi._fire("after_compaction", { messageCount: 200, compactedCount: 5, tokenCount: 8000 }, { agentId: "main", sessionKey: "main" });
-
-    expect(published).toHaveLength(2);
-    expect(JSON.parse(published[0].data).type).toBe("session.compaction_start");
-    expect(JSON.parse(published[0].data).canonicalType).toBe("session.compaction.started");
-    expect(JSON.parse(published[1].data).type).toBe("session.compaction_end");
-    expect(JSON.parse(published[1].data).canonicalType).toBe("session.compaction.ended");
-  });
-
-  it("maps before_reset to session.reset", () => {
-    registerEventHooks(mockApi, defaultConfig(), () => mockClient);
-
-    mockApi._fire("before_reset", { reason: "/new" }, { agentId: "main", sessionKey: "main" });
-
-    expect(published).toHaveLength(1);
-    const event = JSON.parse(published[0].data);
-    expect(event.type).toBe("session.reset");
-    expect(event.payload.reason).toBe("/new");
   });
 
   it("respects excludeHooks config", () => {
@@ -399,8 +44,8 @@ describe("registerEventHooks", () => {
 
     mockApi._fire(
       "message_received",
-      { from: "albert", content: "hello", timestamp: 1000 },
-      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
+      { from: "testuser", content: "hello", timestamp: 1000 },
+      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
     );
 
     expect(published).toHaveLength(0);
@@ -412,8 +57,8 @@ describe("registerEventHooks", () => {
 
     mockApi._fire(
       "message_received",
-      { from: "albert", content: "hello", timestamp: 1000 },
-      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
+      { from: "testuser", content: "hello", timestamp: 1000 },
+      { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
     );
 
     expect(published).toHaveLength(0);
@@ -446,8 +91,8 @@ describe("registerEventHooks", () => {
     expect(() => {
       mockApi._fire(
         "message_received",
-        { from: "albert", content: "hello", timestamp: 1000 },
-        { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:albert" },
+        { from: "testuser", content: "hello", timestamp: 1000 },
+        { channelId: "matrix", agentId: "main", sessionKey: "main:matrix:testuser" },
       );
     }).not.toThrow();
   });
@@ -487,4 +132,3 @@ describe("registerEventHooks", () => {
     expect(runId3).not.toBe(runId1);
   });
 });
-

--- a/packages/openclaw-nats-eventstore/test/integration.test.ts
+++ b/packages/openclaw-nats-eventstore/test/integration.test.ts
@@ -128,8 +128,8 @@ describe.skipIf(!process.env.NATS_URL)("NATS Event Store Integration", () => {
 
     // Fire message_received hook
     hooks["message_received"](
-      { from: "albert", content: "integration test", timestamp: Date.now() },
-      { agentId: "main", sessionKey: "main:matrix:albert", channelId: "matrix" },
+      { from: "testuser", content: "integration test", timestamp: Date.now() },
+      { agentId: "main", sessionKey: "main:matrix:testuser", channelId: "matrix" },
     );
 
     // Give publish time to complete


### PR DESCRIPTION
## Summary

This PR starts Stage 1 of the Brainplex Nervous System / EventStore spinal-cord architecture.

It upgrades `@vainplex/nats-eventstore` from coarse hook logging toward a canonical event backbone while preserving legacy subscribers and subjects.

Key points:

- Adds canonical Brainplex event envelope v1.
- Adds canonical event taxonomy such as `message.in.received`, `tool.call.requested`, `tool.call.executed`, `run.started`, `model.input.observed`.
- Preserves legacy event type and subject routing for compatibility.
- Splits hook mapping logic into dedicated, testable mapping module.
- Keeps LLM input/output content metadata-only and records redaction metadata.

## Relevant Commits

- `38ed9f5 feat(eventstore): add nervous-system event envelope`
- `0960614 fix(eventstore): preserve legacy envelope routing`
- `5519f8f refactor(eventstore): split hook mappings and tests`

## Files Changed

- `packages/openclaw-nats-eventstore/src/events.ts`
- `packages/openclaw-nats-eventstore/src/hooks.ts`
- `packages/openclaw-nats-eventstore/src/hook-mappings.ts`
- `packages/openclaw-nats-eventstore/test/events.test.ts`
- `packages/openclaw-nats-eventstore/test/hooks.test.ts`
- `packages/openclaw-nats-eventstore/test/hook-mappings.test.ts`
- `packages/openclaw-nats-eventstore/test/helpers.ts`
- `packages/openclaw-nats-eventstore/test/integration.test.ts`

## Verification

Run from `/home/keller/repos/vainplex-openclaw`:

```bash
npm test --workspace @vainplex/nats-eventstore
npm run build --workspace @vainplex/nats-eventstore
```

Result:

- Tests: `62 passed, 6 skipped`
- Build: passed

## Pipeline Status

Development pipeline was retroactively restored after an initial direct commit:

- Atlas: architecture gate performed.
- Forge: fixes implemented.
- Cerberus: review performed; findings triggered Forge 2b.
- Forge 2b: review findings fixed.
- Harbor: final QA/deployment check completed.

## Compatibility Notes

Legacy consumers should continue to receive existing subjects and event types via legacy routing and `legacyType` metadata.

The canonical event taxonomy is introduced without requiring consumers to migrate immediately.

## Product Framing

This is not “logging”. It is the first implementation step toward:

> Brainplex gives OpenClaw agents a nervous system: atomic events as nerve impulses, reactive subscribers as organs, Governance as reflexes, Cortex as perception, and EventStore as spinal cord.

## Open Items / Next Stage

Stage 2 should add `brainplex status`:

- read last 50 impulses;
- render timeline;
- show branch/agent/session/run/tool context;
- make the nervous system visible before adding more architecture.

## Do Not Include in PR

The current working tree also contains unrelated dirty files in the repo:

- `CONTRIBUTING.md`
- `README.md`
- `package-lock.json`
- `packages/openclaw-governance/README.md`
- `pnpm-lock.yaml`

These are not part of the EventStore branch work and should not be mixed into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now include rich canonical and legacy type support plus comprehensive envelope metadata (schema version, source, actor, scope, trace), visibility and redaction controls.

* **Refactor**
  * Centralized hook-to-event mapping and envelope construction for consistent event publication and deterministic IDs.

* **Bug Fixes**
  * Preserved legacy routing/compatibility while introducing canonical event types.

* **Tests**
  * Expanded tests covering mappings, envelope fields, deterministic IDs, and privacy/redaction behaviors.

* **Chores**
  * Package bumped to 0.2.2 and docs/config examples updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->